### PR TITLE
Fix build errors after new files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,10 +23,12 @@ LIBFT_LIB   = $(LIBFT_DIR)/libft.a
 
 SRCS =	src/builtins/custom_cd.c \
 		src/builtins/custom_echo.c \
-		src/builtins/custom_exit.c \
-		src/builtins/custom_pwd.c \
-		src/builtins/custom_export.c \
-		src/cleanup.c \
+                src/builtins/custom_exit.c \
+                src/builtins/custom_pwd.c \
+                src/builtins/custom_export.c \
+                src/builtins/custom_env.c \
+                src/builtins/custom_unset.c \
+                src/cleanup.c \
 		src/controller.c \
                 src/handlers.c \
                 src/helpers.c \

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -41,26 +41,33 @@
 # include <readline/history.h>  // rl_clear_history, rl_on_new_line, rl_replace_line, rl_redisplay
 
 // ==================== BUILTIN ====================
+extern int  last_exit_code;
+
 short int   custom_cd(char **envp, char **args);
 short int   custom_exit(char **args);
 short int   custom_echo(char **arg);
-short int   custom_pwd();
-void        custom_export(char **envp);
+short int   custom_pwd(void);
+short int   custom_export(char ***env, char **args);
+short int   custom_unset(char ***envp, char **args);
+short int   custom_env(char **envp);
 
 // ==================== CLEANUP ====================
-void    free_cmd(char **cmd);
+void        free_cmd(char **cmd);
 
 // ==================== CONTROLLER ====================
-void    process_command(char **envp, char *line);
+void        process_command(char ***envp, char *line);
 
 // ==================== HANDLER ====================
-void    run_builtin(char **envp, char **cmd);
+int         run_builtin(char ***envp, char **cmd);
 
 // ==================== HELPERS ====================
-void        execute_command(char *path, char **cmd, char **envp);
+int         execute_command(char *path, char **cmd, char **envp);
 void        execute_pipeline(char **envp, char **segments);
 short int   is_builtin(const char *cmd);
 char        **copy_envp(char **envp);
+int         env_size(char **env);
+char        **env_realloc_add(char **env);
+int         env_add(char ***env_ptr, const char *new_var);
 
 // ==================== UTILS ====================
 char    *get_env_value(char **envp, const char *name);

--- a/src/pipeline.c
+++ b/src/pipeline.c
@@ -75,7 +75,7 @@ void    execute_pipeline(char **envp, char **segments)
             }
             /* execute builtin directly, otherwise try external command */
             if (is_builtin(cmd[0]))
-                run_builtin(envp, cmd);
+                run_builtin(&envp, cmd);
             else
             {
                 char *path = get_path(envp, cmd);


### PR DESCRIPTION
## Summary
- fix prototypes and add `last_exit_code` definition in headers
- compile new builtin sources `custom_env` and `custom_unset`
- adjust pipeline to pass env pointer to `run_builtin`

## Testing
- `make`
- `make fclean`

------
https://chatgpt.com/codex/tasks/task_e_6852db1f4a8483258ab8f4878f448f44