### PR TITLE
Fix pipeline fd handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,8 +45,9 @@ SRCS =	        src/builtins/custom_export/export_check.c \
 				src/parsing/split_pipes.c \
 				src/parsing/tokenize.c \
 				src/piping/pipeline.c \
-				src/piping/redirections.c \
-				src/piping/pipeline_utils.c \
+                                src/piping/redirections.c \
+                                src/piping/redir_utils.c \
+                                src/piping/pipeline_utils.c \
 				src/cleanup.c \
 		        src/controller.c \
 				src/controller_helper.c \

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -85,6 +85,9 @@ void        close_pipe(int *fd);
 void        parent_cleanup(int *in_fd, int *fd, int i, int num);
 void        wait_for_all(pid_t *pids, int count);
 void        execute_pipeline(char **envp, char **segments);
+int         open_infile(char *file, int *in_fd);
+int         open_outfile(char *file, int *out_fd);
+int         open_appendfile(char *file, int *out_fd);
 char        **handle_redirections(char **cmd, int *in_fd, int *out_fd);
 
 // ==================== PARSING ====================

--- a/src/piping/pipeline.c
+++ b/src/piping/pipeline.c
@@ -1,102 +1,89 @@
 #include "minishell.h"
 
-static void     child_process(
-        char **envp, char **cmd, int in_fd, int *fd, int last
-)
+typedef struct s_step
 {
-        int     redir_in;
-        int     redir_out;
+        int             in_fd;
+        int             out_fd;
+        int             pipe_fd[2];
+        char    **cmd;
+}               t_step;
 
-        redir_in = STDIN_FILENO;
-        redir_out = STDOUT_FILENO;
-        cmd = handle_redirections(cmd, &redir_in, &redir_out);
-		if (cmd == NULL)
-    		exit(1);
-        if (redir_in != STDIN_FILENO)
-        {
-			if (redir_in < 0)
-			{
-				perror("Input redirection");
-				exit(1);
-			}
-                dup2(redir_in, STDIN_FILENO);
-                close(redir_in);
-        }
-        else if (in_fd != STDIN_FILENO)
-        {
-                dup2(in_fd, STDIN_FILENO);
-                close(in_fd);
-        }
-        if (!last && redir_out == STDOUT_FILENO)
-                dup2(fd[1], STDOUT_FILENO);
-        else if (redir_out != STDOUT_FILENO)
-		{
-			if (redir_out < 0)
-			{
-				perror("Output redirection");
-				exit(1);
-			}
-			dup2(redir_out, STDOUT_FILENO);
-		}
+static void     child_process(t_step *st, char ***envp, int last)
+{
+        int             save_in;
+        int             save_out;
+
+        save_in = 0;
+        save_out = 0;
+        setup_redirections(st->in_fd, st->out_fd, &save_in, &save_out);
+        if (!last && st->out_fd == STDOUT_FILENO)
+                dup2(st->pipe_fd[1], STDOUT_FILENO);
         if (!last)
         {
-                close(fd[0]);
-                close(fd[1]);
+                close(st->pipe_fd[0]);
+                close(st->pipe_fd[1]);
         }
-        if (redir_out != STDOUT_FILENO)
-                close(redir_out);
-        execute_cmd(envp, cmd);
+        close(save_in);
+        close(save_out);
+        execute_cmd(*envp, st->cmd);
 }
 
+static int      pipeline_step(t_step *st, char ***envp,
+                pid_t *pid, int last)
+{
+        if (!last && pipe(st->pipe_fd) == -1)
+        {
+                perror("pipe");
+                return (0);
+        }
+       st->cmd = prepare_command(st->cmd[0], &st->in_fd, &st->out_fd,
+                       envp);
+       if (!st->cmd)
+       {
+               if (!last)
+                       close_pipe(st->pipe_fd);
+               if (st->in_fd != STDIN_FILENO)
+                       close(st->in_fd);
+               if (st->out_fd != STDOUT_FILENO)
+                       close(st->out_fd);
+               pid[0] = -1;
+               return (1);
+       }
+       pid[0] = fork();
+       if (pid[0] == 0)
+               child_process(st, envp, last);
+       parent_cleanup(&st->in_fd, st->pipe_fd, 0, last ? 1 : 2);
+       if (st->out_fd != STDOUT_FILENO)
+               close(st->out_fd);
+       free_cmd(st->cmd);
+       return (1);
+}
 
-static int	pipeline_step(
-	char **envp, char **segments, pid_t *pids,
-	int *in_fd, int *fd, int i, int num
+static void     pipeline_loop(
+        char ***envp, char **segments, pid_t *pids, int num
 )
 {
-	char	**cmd;
+        t_step  st;
+        int             i;
 
-	if (i < num - 1 && pipe(fd) == -1)
-	{
-		perror("pipe");
-		return (0);
-	}
-
-	cmd = tokenize_command(segments[i], ' ', envp);
-	if (!cmd || !cmd[0])
-	{
-		free_cmd(cmd);
-		if (i < num - 1)
-			close_pipe(fd);
-		return (1);
-	}
-	pids[i] = fork();
-	if (pids[i] == 0)
-		child_process(envp, cmd, *in_fd, fd, i == num - 1);
-	free_cmd(cmd);
-	parent_cleanup(in_fd, fd, i, num);
-	return (1);
+       st.in_fd = STDIN_FILENO;
+       i = 0;
+       while (i < num)
+       {
+               st.cmd = &segments[i];
+               st.out_fd = STDOUT_FILENO;
+               st.pipe_fd[0] = -1;
+               st.pipe_fd[1] = -1;
+               if (!pipeline_step(&st, envp, &pids[i], i == num - 1))
+                       break ;
+               i++;
+       }
+        if (st.in_fd != STDIN_FILENO)
+                close(st.in_fd);
 }
 
-static void	pipeline_loop(
-	char **envp, char **segments, pid_t *pids, int num
-)
-{
-	int	in_fd;
-	int	fd[2];
-	int	i;
 
-	in_fd = STDIN_FILENO;
-	i = 0;
-	while (i < num)
-	{
-		if (!pipeline_step(envp, segments, pids, &in_fd, fd, i, num))
-			break ;
-		i++;
-	}
-	if (in_fd != STDIN_FILENO)
-		close(in_fd);
-}
+
 
 void	execute_pipeline(char **envp, char **segments)
 {
@@ -107,7 +94,7 @@ void	execute_pipeline(char **envp, char **segments)
 	pids = malloc(sizeof(pid_t) * num);
 	if (!pids)
 		return ;
-	pipeline_loop(envp, segments, pids, num);
+        pipeline_loop(&envp, segments, pids, num);
 	wait_for_all(pids, num);
 	free(pids);
 }

--- a/src/piping/pipeline_utils.c
+++ b/src/piping/pipeline_utils.c
@@ -51,9 +51,9 @@ void wait_for_all(pid_t *pids, int count)
     int status;
     while (i < count)
     {
-        if (waitpid(pids[i], &status, 0) == -1)
+        if (pids[i] != -1 && waitpid(pids[i], &status, 0) == -1)
             perror("waitpid");
-        if (i == count - 1)
+        if (i == count - 1 && pids[i] != -1)
         {
             if (WIFEXITED(status))
                 g_exit_code = WEXITSTATUS(status);

--- a/src/piping/redir_utils.c
+++ b/src/piping/redir_utils.c
@@ -1,0 +1,67 @@
+#include "minishell.h"
+#include <errno.h>
+
+int     open_infile(char *file, int *in_fd)
+{
+        int     fd;
+
+        fd = 0;
+        if (*in_fd != STDIN_FILENO)
+                close(*in_fd);
+        fd = open(file, O_RDONLY);
+        if (fd < 0)
+        {
+                perror(file);
+                if (errno == EACCES)
+                        g_exit_code = 126;
+                else if (errno == ENOENT)
+                        g_exit_code = 127;
+                else
+                        g_exit_code = 1;
+                return (-1);
+        }
+        *in_fd = fd;
+        return (0);
+}
+
+int     open_outfile(char *file, int *out_fd)
+{
+        int     fd;
+
+        fd = 0;
+        if (*out_fd != STDOUT_FILENO)
+                close(*out_fd);
+        fd = open(file, O_WRONLY | O_CREAT | O_TRUNC, 0644);
+        if (fd < 0)
+        {
+                perror(file);
+                if (errno == EACCES)
+                        g_exit_code = 126;
+                else
+                        g_exit_code = 1;
+                return (-1);
+        }
+        *out_fd = fd;
+        return (0);
+}
+
+int     open_appendfile(char *file, int *out_fd)
+{
+        int     fd;
+
+        fd = 0;
+        if (*out_fd != STDOUT_FILENO)
+                close(*out_fd);
+        fd = open(file, O_WRONLY | O_CREAT | O_APPEND, 0644);
+        if (fd < 0)
+        {
+                perror(file);
+                if (errno == EACCES)
+                        g_exit_code = 126;
+                else
+                        g_exit_code = 1;
+                return (-1);
+        }
+        *out_fd = fd;
+        return (0);
+}

--- a/src/piping/redirections.c
+++ b/src/piping/redirections.c
@@ -1,168 +1,110 @@
 #include "minishell.h"
 #include "../libft/libft.h"
-#include <errno.h> 
 
-int open_infile(char *file, int *in_fd)
+static void     write_heredoc(int fd, const char *delim)
 {
-    int fd;
-
-    fd = 0;
-    if (*in_fd != STDIN_FILENO)
-        close(*in_fd);
-
-    fd = open(file, O_RDONLY);
-    if (fd < 0)
-    {
-        perror(file);
-        if (errno == EACCES)
-            g_exit_code = 126;
-        else if (errno == ENOENT)
-            g_exit_code = 127;
-        else
-            g_exit_code = 1;
-        return -1;
-    }
-    *in_fd = fd;
-    return 0;
-}
-
-int open_outfile(char *file, int *out_fd)
-{
-    int fd;
-    fd = 0;
-    if (*out_fd != STDOUT_FILENO)
-        close(*out_fd);
-
-    fd = open(file, O_WRONLY | O_CREAT | O_TRUNC, 0644);
-    if (fd < 0)
-    {
-        perror(file);
-        if (errno == EACCES)
-            g_exit_code = 126;
-        else
-            g_exit_code = 1;
-        return -1;
-    }
-
-    *out_fd = fd;
-    return 0;
-}
-
-int open_appendfile(char *file, int *out_fd)
-{
-    int fd;
-    fd = 0;
-    if (*out_fd != STDOUT_FILENO)
-        close(*out_fd);
-
-    fd = open(file, O_WRONLY | O_CREAT | O_APPEND, 0644);
-    if (fd < 0)
-    {
-        perror(file);
-        if (errno == EACCES)
-            g_exit_code = 126;
-        else
-            g_exit_code = 1;
-        return -1;
-    }
-
-    *out_fd = fd;
-    return 0;
-}
-
-static int open_heredoc(const char *delim)
-{
-    int pipefd[2];
-    char *line;
-
-    if (pipe(pipefd) == -1)
-    {
-        perror("pipe");
-        g_exit_code = 1;
-        return -1;
-    }
+    char    *line;
 
     while (1)
     {
-        line = readline("> ");
-        if (!line || ft_strcmp(line, delim) == 0)
-        {
+            line = readline("> ");
+            if (!line || ft_strcmp(line, delim) == 0)
+            {
+                    free(line);
+                    break ;
+            }
+            write(fd, line, ft_strlen(line));
+            write(fd, "\n", 1);
             free(line);
-            break;
-        }
-        write(pipefd[1], line, ft_strlen(line));
-        write(pipefd[1], "\n", 1);
-        free(line);
     }
-
-    close(pipefd[1]);
-    return pipefd[0];
 }
 
-static int handle_heredoc(const char *delim, int *in_fd)
+static int      handle_heredoc(const char *delim, int *in_fd)
 {
-    int h = open_heredoc(delim);
-    if (h < 0)
-        return -1;
+    int             pipefd[2];
 
+    if (pipe(pipefd) == -1)
+    {
+            perror("pipe");
+            g_exit_code = 1;
+            return (-1);
+    }
+    write_heredoc(pipefd[1], delim);
+    close(pipefd[1]);
     if (*in_fd != STDIN_FILENO)
-        close(*in_fd);
-
-    *in_fd = h;
-    return 0;
+            close(*in_fd);
+    *in_fd = pipefd[0];
+    return (0);
 }
+
+
+static int      apply_in_redir(char **cmd, int *i, int *in_fd)
+{
+    if (!ft_strcmp(cmd[*i], "<") && cmd[*i + 1])
+    {
+            if (open_infile(cmd[*i + 1], in_fd) == -1)
+                    return (-1);
+            *i += 2;
+            return (1);
+    }
+    if (!ft_strcmp(cmd[*i], "<<") && cmd[*i + 1])
+    {
+            if (handle_heredoc(cmd[*i + 1], in_fd) == -1)
+                    return (-1);
+            *i += 2;
+            return (1);
+    }
+    return (0);
+}
+
+static int      apply_redir(char **cmd, int *i, int *in_fd, int *out_fd)
+{
+    int     ret;
+
+    ret = apply_in_redir(cmd, i, in_fd);
+    if (ret)
+            return (ret);
+    if (!ft_strcmp(cmd[*i], ">") && cmd[*i + 1])
+    {
+            if (open_outfile(cmd[*i + 1], out_fd) == -1)
+                    return (-1);
+            *i += 2;
+            return (1);
+    }
+    if (!ft_strcmp(cmd[*i], ">>") && cmd[*i + 1])
+    {
+            if (open_appendfile(cmd[*i + 1], out_fd) == -1)
+                    return (-1);
+            *i += 2;
+            return (1);
+    }
+    return (0);
+}
+
 
 char **handle_redirections(char **cmd, int *in_fd, int *out_fd)
 {
-    int     i = 0;
-    int     j = 0;
-    int     cnt = count_strings(cmd);
-    char  **clean = malloc(sizeof(char *) * (cnt + 1));
-
+    int     i;
+    int     j;
+    char    **clean;
+    int     ret;
+    i = 0; j = 0;
+    clean = malloc(sizeof(char *) * (count_strings(cmd) + 1));
     if (!clean)
-        return (NULL);
+            return (NULL);
     while (cmd[i])
     {
-        if (!ft_strcmp(cmd[i], "<") && cmd[i + 1])
-        {
-            if (open_infile(cmd[i + 1], in_fd) == -1)
+            ret = apply_redir(cmd, &i, in_fd, out_fd);
+            if (ret == -1)
             {
-                free(clean);
-                return NULL;
+                    free(clean);
+                    return (NULL);
             }
-            i += 2;
-        }
-        else if (!ft_strcmp(cmd[i], "<<") && cmd[i + 1])
-        {
-            if (handle_heredoc(cmd[i + 1], in_fd) == -1)
-            {
-                free(clean);
-                return NULL;
-            }
-            i += 2;
-        }
-        else if (!ft_strcmp(cmd[i], ">") && cmd[i + 1])
-        {
-            if (open_outfile(cmd[i + 1], out_fd) == -1)
-            {
-                free(clean);
-                return NULL;
-            }
-            i += 2;
-        }
-        else if (!ft_strcmp(cmd[i], ">>") && cmd[i + 1])
-        {
-            if (open_appendfile(cmd[i + 1], out_fd) == -1)
-            {
-                free(clean);
-                return NULL;
-            }
-            i += 2;
-        }
-        else
-            clean[j++] = cmd[i++];
+            if (ret == 0)
+                    clean[j++] = cmd[i++];
     }
     clean[j] = NULL;
     free(cmd);
     return (clean);
 }
+


### PR DESCRIPTION
## Summary
- correctly reset pipe state between pipeline steps
- mark skipped commands in the pids array
- close unused redirection fds
- ignore invalid pids when waiting

## Testing
- `make`


------
https://chatgpt.com/codex/tasks/task_e_688a24a9f84c83259bd7f2e4312e2cc3