### PR TITLE
Refactor parsing to follow 42 norm

### DIFF
--- a/src/parsing/expander.c
+++ b/src/parsing/expander.c
@@ -10,18 +10,54 @@ static char	*append_exit_code(char *result, int *i, char *str, int *handled)
 	if (!(str[*i] == '$' && str[*i + 1] == '?'))
 		return (result);
 	*handled = 1;
-	if (!(result = append_literal(result, str, 0, *i)))
+	result = append_literal(result, str, 0, *i);
+	if (!result)
 		return (NULL);
 	exit_code_str = ft_itoa(g_exit_code);
 	if (!exit_code_str)
-		return (free(result), NULL);
+	{
+		free(result);
+		return (NULL);
+	}
 	tmp = ft_strcatrealloc(result, exit_code_str);
 	free(exit_code_str);
 	if (!tmp)
-		return (free(result), NULL);
+	{
+		free(result);
+		return (NULL);
+	}
 	result = tmp;
 	*i += 2;
 	return (result);
+}
+
+static int	handle_dollar(char **result, char *str, int *i,
+		int *start, char **envp)
+{
+	int	handled;
+
+	if (str[*i] != '$')
+		return (0);
+	*result = append_exit_code(*result, i, str, &handled);
+	if (!*result)
+		return (-1);
+	if (handled)
+	{
+		*start = *i;
+		return (1);
+	}
+	if (ft_isalnum(str[*i + 1]))
+	{
+		*result = append_literal(*result, str, *start, *i);
+		if (!*result)
+			return (-1);
+		*result = append_expanded_var(*result, str, i, envp);
+		if (!*result)
+			return (-1);
+		*start = *i;
+		return (1);
+	}
+	return (0);
 }
 
 char	*build_expanded_str(char *str, char **envp)
@@ -29,34 +65,22 @@ char	*build_expanded_str(char *str, char **envp)
 	int		i;
 	int		start;
 	char	*result;
-	int		handled;
+	int		status;
 
 	i = 0;
 	start = 0;
 	result = NULL;
 	while (str[i])
 	{
-		if (str[i] == '$')
-		{
-			if ((result = append_exit_code(result, &i, str, &handled))
-				&& handled)
-			{
-				start = i;
-				continue ;
-			}
-			if (ft_isalnum(str[i + 1]))
-			{
-				if (!(result = append_literal(result, str, start, i)))
-					return (NULL);
-				if (!(result = append_expanded_var(result, str, &i, envp)))
-					return (NULL);
-				start = i;
-				continue ;
-			}
-		}
+		status = handle_dollar(&result, str, &i, &start, envp);
+		if (status == -1)
+			return (NULL);
+		if (status == 1)
+			continue ;
 		i++;
 	}
-	if (!(result = ft_strcatrealloc(result, str + start)))
+	result = ft_strcatrealloc(result, str + start);
+	if (!result)
 		return (NULL);
 	return (result);
 }

--- a/src/parsing/split_pipes.c
+++ b/src/parsing/split_pipes.c
@@ -31,6 +31,12 @@ static void	handle_quote_state(char c, char *quote)
 		*quote = 0;
 }
 
+static void	add_segment(char **arr, size_t *seg, const char *line, size_t start, size_t end)
+{
+	arr[*seg] = ft_substr(line, start, end - start);
+	(*seg)++;
+}
+
 char	**split_pipes(const char *line)
 {
 	size_t	i;
@@ -51,12 +57,12 @@ char	**split_pipes(const char *line)
 		handle_quote_state(line[i], &quote);
 		if (!quote && line[i] == '|')
 		{
-			arr[seg++] = ft_substr(line, start, i - start);
+			add_segment(arr, &seg, line, start, i);
 			start = i + 1;
 		}
 		i++;
 	}
-	arr[seg++] = ft_substr(line, start, i - start);
+	add_segment(arr, &seg, line, start, i);
 	arr[seg] = NULL;
 	return (arr);
 }


### PR DESCRIPTION
## Summary
- Refactor expansion to use helper function and eliminate assignments in conditions
- Rewrite redirection and pipe splitting into smaller helpers
- Simplify tokenization flow to satisfy 42 norms

## Testing
- `make`
- `printf 'echo hello world\nexit\n' | ./minishell`
- `printf 'export VAR=hi\necho $VAR test\nexit\n' | ./minishell`
- `printf 'echo hi | cat\nexit\n' | ./minishell`
- `printf 'echo hi > tmpfile\ncat < tmpfile\nexit\n' | ./minishell`


------
https://chatgpt.com/codex/tasks/task_e_6894e2cc5c78832593667abe0908d998