### PR TITLE
Refactor parsing module for 42 Norm compliance

### DIFF
--- a/src/parsing/expander.c
+++ b/src/parsing/expander.c
@@ -1,62 +1,88 @@
 #include "../libft/libft.h"
 #include "minishell.h"
 
-static char	*append_exit_code(char *result, int *i, char *str, int *handled)
+typedef struct s_expand
+{
+	char	*str;
+	char	**envp;
+	char	*result;
+	int		start;
+}	t_expand;
+
+static char *append_exit_code(char *result, char *str, int *i)
 {
 	char	*exit_code_str;
 	char	*tmp;
 
-	*handled = 0;
-	if (!(str[*i] == '$' && str[*i + 1] == '?'))
-		return (result);
-	*handled = 1;
-	if (!(result = append_literal(result, str, 0, *i)))
+	result = append_literal(result, str, 0, *i);
+	if (!result)
 		return (NULL);
 	exit_code_str = ft_itoa(g_exit_code);
 	if (!exit_code_str)
-		return (free(result), NULL);
+	{
+		free(result);
+		return (NULL);
+	}
 	tmp = ft_strcatrealloc(result, exit_code_str);
 	free(exit_code_str);
 	if (!tmp)
-		return (free(result), NULL);
+	{
+		free(result);
+		return (NULL);
+	}
 	result = tmp;
 	*i += 2;
 	return (result);
 }
 
+static int handle_dollar(t_expand *d, int *i)
+{
+	if (d->str[*i] != '$')
+		return (0);
+	if (d->str[*i + 1] == '?')
+	{
+		d->result = append_exit_code(d->result, d->str, i);
+		if (!d->result)
+			return (-1);
+		d->start = *i;
+		return (1);
+	}
+	if (ft_isalnum(d->str[*i + 1]))
+	{
+		d->result = append_literal(d->result, d->str, d->start, *i);
+		if (!d->result)
+			return (-1);
+		d->result = append_expanded_var(d->result, d->str, i, d->envp);
+		if (!d->result)
+			return (-1);
+		d->start = *i;
+		return (1);
+	}
+	return (0);
+}
+
 char	*build_expanded_str(char *str, char **envp)
 {
-	int		i;
-	int		start;
-	char	*result;
-	int		handled;
+	int			i;
+	int			status;
+	t_expand	d;
 
 	i = 0;
-	start = 0;
-	result = NULL;
+	d.str = str;
+	d.envp = envp;
+	d.result = NULL;
+	d.start = 0;
 	while (str[i])
 	{
-		if (str[i] == '$')
-		{
-			if ((result = append_exit_code(result, &i, str, &handled))
-				&& handled)
-			{
-				start = i;
-				continue ;
-			}
-			if (ft_isalnum(str[i + 1]))
-			{
-				if (!(result = append_literal(result, str, start, i)))
-					return (NULL);
-				if (!(result = append_expanded_var(result, str, &i, envp)))
-					return (NULL);
-				start = i;
-				continue ;
-			}
-		}
+		status = handle_dollar(&d, &i);
+		if (status == -1)
+			return (NULL);
+		if (status == 1)
+			continue ;
 		i++;
 	}
-	if (!(result = ft_strcatrealloc(result, str + start)))
+	d.result = ft_strcatrealloc(d.result, str + d.start);
+	if (!d.result)
 		return (NULL);
-	return (result);
+	return (d.result);
 }

--- a/src/parsing/redir_split.c
+++ b/src/parsing/redir_split.c
@@ -1,11 +1,18 @@
 #include "../libft/libft.h"
 #include "minishell.h"
 
+typedef struct s_redir
+{
+	int		j;
+	int		idx;
+	int		start;
+}	t_redir;
+
 static int	part_count(char *tok)
 {
-	int	i;
-	int	start;
-	int	count;
+	int i;
+	int start;
+	int count;
 
 	i = 0;
 	start = 0;
@@ -17,19 +24,13 @@ static int	part_count(char *tok)
 			if (i - start > 0)
 				count++;
 			if (tok[i] == '>' && tok[i + 1] == '>')
-			{
-				count++;
-				i += 2;
-			}
-			else
-			{
-				count++;
 				i++;
-			}
-			start = i;
-		}
-		else
+			count++;
 			i++;
+			start = i;
+			continue ;
+		}
+		i++;
 	}
 	if (i - start > 0)
 		count++;
@@ -38,8 +39,8 @@ static int	part_count(char *tok)
 
 static int	total_parts(char **arr)
 {
-	int	total;
-	int	i;
+	int total;
+	int i;
 
 	total = 0;
 	i = 0;
@@ -51,55 +52,78 @@ static int	total_parts(char **arr)
 	return (total);
 }
 
+static void handle_redir(char **out, char *tok, t_redir *st)
+{
+	char	op[2];
+
+	if (st->j - st->start > 0)
+	{
+		out[st->idx] = ft_substr(tok, st->start, st->j - st->start);
+		st->idx++;
+	}
+	if (tok[st->j] == '>' && tok[st->j + 1] == '>')
+	{
+		out[st->idx] = ft_strdup(">>");
+		st->j += 2;
+	}
+	else
+	{
+		op[0] = tok[st->j];
+		op[1] = '\0';
+		out[st->idx] = ft_strdup(op);
+		st->j++;
+	}
+	st->idx++;
+	st->start = st->j;
+}
+
+static void process_token(char **out, char *tok, int *idx)
+{
+	t_redir st;
+	char	quote;
+
+	st.j = 0;
+	st.start = 0;
+	st.idx = *idx;
+	quote = 0;
+	while (tok[st.j])
+	{
+		if (!quote && (tok[st.j] == '\'' || tok[st.j] == '"'))
+			quote = tok[st.j];
+		else if (quote && tok[st.j] == quote)
+			quote = 0;
+		else if (!quote && (tok[st.j] == '>' || tok[st.j] == '<'))
+		{
+			handle_redir(out, tok, &st);
+			continue ;
+		}
+		st.j++;
+	}
+	if (st.j - st.start > 0)
+	{
+		out[st.idx] = ft_substr(tok, st.start, st.j - st.start);
+		st.idx++;
+	}
+	*idx = st.idx;
+}
+
 char	**split_redirs(char **arr)
 {
 	char	**out;
 	int		i;
-	int		j;
-	int		start;
 	int		idx;
-	char	quote;
-	char	op[2];
 
 	out = malloc(sizeof(char *) * (total_parts(arr) + 1));
 	if (!out)
-		return (free_cmd(arr), NULL);
+	{
+		free_cmd(arr);
+		return (NULL);
+	}
 	idx = 0;
 	i = 0;
 	while (arr[i])
 	{
-		j = 0;
-		start = 0;
-		quote = 0;
-		while (arr[i][j])
-		{
-			if (!quote && (arr[i][j] == '\'' || arr[i][j] == '"'))
-				quote = arr[i][j];
-			else if (quote && arr[i][j] == quote)
-				quote = 0;
-			if (!quote && (arr[i][j] == '>' || arr[i][j] == '<'))
-			{
-				if (j - start > 0)
-					out[idx++] = ft_substr(arr[i], start, j - start);
-				if (arr[i][j] == '>' && arr[i][j + 1] == '>')
-				{
-					out[idx++] = ft_strdup(">>");
-					j += 2;
-				}
-				else
-				{
-					op[0] = arr[i][j];
-					op[1] = '\0';
-					out[idx++] = ft_strdup(op);
-					j++;
-				}
-				start = j;
-			}
-			else
-				j++;
-		}
-		if (j - start > 0)
-			out[idx++] = ft_substr(arr[i], start, j - start);
+		process_token(out, arr[i], &idx);
 		free(arr[i]);
 		i++;
 	}

--- a/src/parsing/split_pipes.c
+++ b/src/parsing/split_pipes.c
@@ -1,6 +1,12 @@
 #include "../libft/libft.h"
 #include "minishell.h"
 
+typedef struct s_pipe
+{
+	char	**arr;
+	size_t	seg;
+}	t_pipe;
+
 static size_t	count_segments(const char *line)
 {
 	size_t	i;
@@ -23,7 +29,7 @@ static size_t	count_segments(const char *line)
 	return (count);
 }
 
-static void	handle_quote_state(char c, char *quote)
+static void handle_quote_state(char c, char *quote)
 {
 	if (!*quote && (c == '\'' || c == '"'))
 		*quote = c;
@@ -31,32 +37,37 @@ static void	handle_quote_state(char c, char *quote)
 		*quote = 0;
 }
 
+static void add_segment(t_pipe *p, const char *line, size_t start, size_t end)
+{
+	p->arr[p->seg] = ft_substr(line, start, end - start);
+	p->seg++;
+}
+
 char	**split_pipes(const char *line)
 {
 	size_t	i;
 	size_t	start;
-	size_t	seg;
 	char	quote;
-	char	**arr;
+	t_pipe	p;
 
 	i = 0;
 	start = 0;
-	seg = 0;
 	quote = 0;
-	arr = malloc(sizeof(char *) * (count_segments(line) + 1));
-	if (!arr)
+	p.seg = 0;
+	p.arr = malloc(sizeof(char *) * (count_segments(line) + 1));
+	if (!p.arr)
 		return (NULL);
 	while (line && line[i])
 	{
 		handle_quote_state(line[i], &quote);
 		if (!quote && line[i] == '|')
 		{
-			arr[seg++] = ft_substr(line, start, i - start);
+			add_segment(&p, line, start, i);
 			start = i + 1;
 		}
 		i++;
 	}
-	arr[seg++] = ft_substr(line, start, i - start);
-	arr[seg] = NULL;
-	return (arr);
+	add_segment(&p, line, start, i);
+	p.arr[p.seg] = NULL;
+	return (p.arr);
 }

--- a/src/parsing/tokenize.c
+++ b/src/parsing/tokenize.c
@@ -17,31 +17,16 @@ static size_t	token_count(char const *s, char c)
 			break ;
 		count++;
 		quote = 0;
-		while (s[i])
+		while (s[i] && (quote || s[i] != c))
 		{
-			if (!quote && (s[i] == '"' || s[i] == '\''))
-			{
-				quote = s[i++];
-				while (s[i] && s[i] != quote)
-					i++;
-				if (s[i] == quote)
-					i++;
+			if (!quote && (s[i] == '\'' || s[i] == '"'))
+				quote = s[i];
+			else if (quote && s[i] == quote)
 				quote = 0;
-				continue ;
-			}
-			if (!quote && s[i] == c)
-				break ;
 			i++;
 		}
 	}
 	return (count);
-}
-
-static void	free_arr(char **arr, int i)
-{
-	while (i-- > 0)
-		free(arr[i]);
-	free(arr);
 }
 
 static size_t	next_c(char *s, char c)
@@ -55,7 +40,8 @@ static size_t	next_c(char *s, char c)
 	{
 		if (!quote && (s[len] == '"' || s[len] == '\''))
 		{
-			quote = s[len++];
+			quote = s[len];
+			len++;
 			while (s[len] && s[len] != quote)
 				len++;
 			if (s[len] == quote)
@@ -70,18 +56,31 @@ static size_t	next_c(char *s, char c)
 	return (len);
 }
 
-char	**tokenize_command(char const *s, char c, char **envp)
+static char *get_token(char const **s, char c, char **envp)
 {
-	char	**arr;
-	int		i;
 	size_t	len;
+	char	*tok;
 	char	*expanded;
 
-	if (!s)
+	len = next_c((char *)*s, c);
+	tok = ft_substr((char *)*s, 0, len);
+	if (!tok)
 		return (NULL);
-	arr = (char **)malloc((token_count(s, c) + 1) * sizeof(char *));
-	if (!arr)
-		return (NULL);
+	if (tok[0] != '\'')
+	{
+		expanded = build_expanded_str(tok, envp);
+		free(tok);
+		tok = expanded;
+	}
+	*s += len;
+	return (tok);
+}
+
+static int	fill_tokens(char **arr, char const *s, char c, char **envp)
+{
+	int		i;
+	char	*tok;
+
 	i = 0;
 	while (*s)
 	{
@@ -89,20 +88,37 @@ char	**tokenize_command(char const *s, char c, char **envp)
 			s++;
 		if (!*s)
 			break ;
-		len = next_c((char *)s, c);
-		arr[i] = ft_substr((char *)s, 0, len);
-		if (!arr[i])
-			return (free_arr(arr, i), NULL);
-		if (arr[i][0] != '\'')
+		tok = get_token(&s, c, envp);
+		if (!tok)
 		{
-			expanded = build_expanded_str(arr[i], envp);
-			free(arr[i]);
-			arr[i] = expanded;
+			while (i > 0)
+			{
+				i--;
+				free(arr[i]);
+			}
+			free(arr);
+			return (-1);
 		}
+		arr[i] = tok;
 		i++;
-		s += len;
 	}
 	arr[i] = NULL;
+	return (i);
+}
+
+char	**tokenize_command(char const *s, char c, char **envp)
+{
+	char	**arr;
+	int		i;
+
+	if (!s)
+		return (NULL);
+	arr = (char **)malloc((token_count(s, c) + 1) * sizeof(char *));
+	if (!arr)
+		return (NULL);
+	i = fill_tokens(arr, s, c, envp);
+	if (i < 0)
+		return (NULL);
 	arr = split_redirs(arr);
 	if (!arr)
 		return (NULL);


### PR DESCRIPTION
## Summary
- refactor expander to use `t_expand` and keep dollar handling within 25-line/4-arg limits
- streamline redirection splitter with `t_redir` state struct and shorter helpers
- rework pipe splitting and tokenization helpers to remove excess parameters

## Testing
- `make`
- `cat cmds.txt | ./minishell`
- `bash cmds.txt`

------
https://chatgpt.com/codex/tasks/task_e_6894e2cc5c78832593667abe0908d998