### PR TITLE
Fix word splitting in variable expansion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,12 +39,13 @@ SRCS =	        src/builtins/custom_export/export_check.c \
 				src/env/env_lookup.c \
 				src/env/env_utils.c \
 				src/misc/utils.c \
-				src/parsing/expander_utils.c \
-				src/parsing/expander.c \
-				src/parsing/redir_split.c \
-				src/parsing/split_pipes.c \
-				src/parsing/tokenize.c \
-				src/piping/pipeline.c \
+src/parsing/expander_utils.c \
+src/parsing/expander.c \
+src/parsing/redir_split.c \
+src/parsing/split_pipes.c \
+src/parsing/tokenize.c \
+src/parsing/word_split.c \
+src/piping/pipeline.c \
 				src/piping/redirections.c \
 				src/piping/pipeline_utils.c \
 				src/piping/redirections_utils.c \

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -111,6 +111,7 @@ char        *append_literal(char *result, char *str, int start, int i);
 char        *expand_var(char *str, int *var_len);
 char        *append_expanded_var(char *result, char *str, int *i, char **envp);
 char        *build_expanded_str(char *str, char **envp);
+char        **split_expanded_tokens(char **arr);
 char        **split_redirs(char **arr);
 char        **tokenize_command(char const *s, char c, char **envp);
 char        **split_pipes(const char *line);

--- a/src/parsing/tokenize.c
+++ b/src/parsing/tokenize.c
@@ -125,10 +125,13 @@ char	**tokenize_command(char const *s, char c, char **envp)
 	token_num = fill_arr_from_string(s, c, arr, envp);
 	if (token_num < 0)
 		return (free_cmd(arr), NULL);
-	arr[token_num] = NULL;
-	arr = split_redirs(arr);
-	if (!arr)
-		return (NULL);
+        arr[token_num] = NULL;
+        arr = split_expanded_tokens(arr);
+        if (!arr)
+                return (NULL);
+        arr = split_redirs(arr);
+        if (!arr)
+                return (NULL);
 	i = 0;
 	while (arr[i])
 	{

--- a/src/parsing/word_split.c
+++ b/src/parsing/word_split.c
@@ -1,0 +1,59 @@
+#include "../libft/libft.h"
+#include "minishell.h"
+
+char **split_expanded_tokens(char **arr)
+{
+    int i;
+    int j;
+    int k;
+    int total;
+    char **parts;
+    char **out;
+
+    i = 0;
+    total = 0;
+    while (arr && arr[i])
+    {
+        if (ft_strchr(arr[i], '\'') || ft_strchr(arr[i], '"'))
+            total++;
+        else
+        {
+            parts = ft_split(arr[i], ' ');
+            if (!parts)
+                return (free_cmd(arr), NULL);
+            total += count_strings(parts);
+            free_cmd(parts);
+        }
+        i++;
+    }
+    out = malloc(sizeof(char *) * (total + 1));
+    if (!out)
+        return (free_cmd(arr), NULL);
+    i = 0;
+    k = 0;
+    while (arr && arr[i])
+    {
+        if (ft_strchr(arr[i], '\'') || ft_strchr(arr[i], '"'))
+            out[k++] = arr[i];
+        else
+        {
+            parts = ft_split(arr[i], ' ');
+            free(arr[i]);
+            if (!parts)
+            {
+                free_cmd(out);
+                free_cmd(arr + i + 1);
+                free(arr);
+                return (NULL);
+            }
+            j = 0;
+            while (parts[j])
+                out[k++] = parts[j++];
+            free(parts);
+        }
+        i++;
+    }
+    out[k] = NULL;
+    free(arr);
+    return (out);
+}


### PR DESCRIPTION
## Summary
- handle word splitting after variable expansion
- include new parsing helper for splitting expanded tokens

## Testing
- `make`
- `printf 'export PWD="a b"\ncd $PWD\n$PWD\nexit\n' | ./minishell`


------
https://chatgpt.com/codex/tasks/task_e_68a5999164308325a93e2ee6d0ee8731