### PR TITLE
Handle quoted expansion and heredoc cleanup

### DIFF
--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -101,8 +101,8 @@ void        close_pipe(int *fd);
 void        parent_cleanup(int *in_fd, int *fd, int i, int num);
 void        wait_for_all(pid_t *pids, int count);
 void        execute_pipeline(char **envp, char **segments);
-char        **handle_redirections(char **cmd, int count, int *in_fd, int *out_fd);
-int	        handle_heredoc(const char *delim, int *in_fd);
+char        **handle_redirections(char **cmd, int *quoted, int count, char **envp, int *in_fd, int *out_fd);
+int             handle_heredoc(const char *delim, int quoted, char **envp, int *in_fd);
 void        pipeline_loop(t_pipeline_data *pipeline);
 
 // ==================== PARSING ====================
@@ -113,7 +113,7 @@ char        *append_expanded_var(char *result, char *str, int *i, char **envp);
 char        *build_expanded_str(char *str, char **envp);
 char        **split_expanded_tokens(char **arr);
 char        **split_redirs(char **arr);
-char        **tokenize_command(char const *s, char c, char **envp);
+char        **tokenize_command(char const *s, char c, char **envp, int **quoted);
 char        **split_pipes(const char *line);
 
 // ==================== MISC ====================

--- a/src/controller_helper.c
+++ b/src/controller_helper.c
@@ -14,82 +14,86 @@
 #include "minishell.h"
 #include <fcntl.h>
 
-int	is_folder(char *arg)
+int     is_folder(char *arg)
 {
-	int	fd_test;
+        int     fd_test;
 
-	fd_test = open(arg, O_DIRECTORY);
-	if (fd_test != -1)
-	{
-		close(fd_test);
-		return (126);
-	}
-	return (0);
+        fd_test = open(arg, O_DIRECTORY);
+        if (fd_test != -1)
+        {
+                close(fd_test);
+                return (126);
+        }
+        return (0);
 }
 
-char	**prepare_command(char *segment, int *in_fd, int *out_fd, char ***envp)
+char    **prepare_command(char *segment, int *in_fd, int *out_fd, char ***envp)
 {
-	char	**cmd;
+        char    **cmd;
+        int             *quoted;
 
-	cmd = tokenize_command(segment, ' ', *envp);
-	if (!cmd)
-		return (NULL);
-	cmd = handle_redirections(cmd, count_strings(cmd) + 1, in_fd, out_fd);
-	if (!cmd || !cmd[0])
-	{
-		free_cmd(cmd);
-		return (NULL);
-	}
-	return (cmd);
+        cmd = tokenize_command(segment, ' ', *envp, &quoted);
+        if (!cmd)
+                return (NULL);
+        cmd = handle_redirections(cmd, quoted, count_strings(cmd) + 1, *envp,
+                        in_fd, out_fd);
+        free(quoted);
+        if (!cmd || !cmd[0])
+        {
+                free_cmd(cmd);
+                return (NULL);
+        }
+        return (cmd);
 }
 
-void setup_redirections(int in_fd, int out_fd, int *save_in, int *save_out)
+void    setup_redirections(int in_fd, int out_fd, int *save_in, int *save_out)
 {
-    *save_in = -1;
-    *save_out = -1;
+        *save_in = -1;
+        *save_out = -1;
 
-    if (in_fd != STDIN_FILENO)
-    {
-        *save_in = dup(STDIN_FILENO);
-        if (*save_in == -1)
-            perror("dup");
-        if (dup2(in_fd, STDIN_FILENO) == -1)
-            perror("dup2");
-        close(in_fd);
-    }
+        if (in_fd != STDIN_FILENO)
+        {
+                *save_in = dup(STDIN_FILENO);
+                if (*save_in == -1)
+                        perror("dup");
+                if (dup2(in_fd, STDIN_FILENO) == -1)
+                        perror("dup2");
+                close(in_fd);
+        }
 
-    if (out_fd != STDOUT_FILENO)
-    {
-        *save_out = dup(STDOUT_FILENO);
-        if (*save_out == -1)
-            perror("dup");
-        if (dup2(out_fd, STDOUT_FILENO) == -1)
-            perror("dup2");
-        close(out_fd);
-    }
+        if (out_fd != STDOUT_FILENO)
+        {
+                *save_out = dup(STDOUT_FILENO);
+                if (*save_out == -1)
+                        perror("dup");
+                if (dup2(out_fd, STDOUT_FILENO) == -1)
+                        perror("dup2");
+                close(out_fd);
+        }
 }
 
-void restore_redirections(int save_in, int save_out)
+void    restore_redirections(int save_in, int save_out)
 {
-    if (save_in != -1)
-    {
-        if (dup2(save_in, STDIN_FILENO) == -1)
-            perror("dup2");
-        close(save_in);
-    }
+        if (save_in != -1)
+        {
+                if (dup2(save_in, STDIN_FILENO) == -1)
+                        perror("dup2");
+                close(save_in);
+        }
 
-    if (save_out != -1)
-    {
-        if (dup2(save_out, STDOUT_FILENO) == -1)
-            perror("dup2");
-        close(save_out);
-    }
+        if (save_out != -1)
+        {
+                if (dup2(save_out, STDOUT_FILENO) == -1)
+                        perror("dup2");
+                close(save_out);
+        }
 }
 
-short int	is_builtin(const char *cmd)
+short int       is_builtin(const char *cmd)
 {
-	return (ft_strncmp(cmd, "echo", 5) == 0 || ft_strncmp(cmd, "cd", 3) == 0
-		|| ft_strncmp(cmd, "pwd", 4) == 0 || ft_strncmp(cmd, "export", 7) == 0
-		|| ft_strncmp(cmd, "unset", 6) == 0 || ft_strncmp(cmd, "env", 4) == 0
-		|| ft_strncmp(cmd, "exit", 5) == 0);
+        return (ft_strncmp(cmd, "echo", 5) == 0 || ft_strncmp(cmd, "cd", 3) == 0
+                || ft_strncmp(cmd, "pwd", 4) == 0 || ft_strncmp(cmd, "export", 7) == 0
+                || ft_strncmp(cmd, "unset", 6) == 0 || ft_strncmp(cmd, "env", 4) == 0
+                || ft_strncmp(cmd, "exit", 5) == 0);
 }
+

--- a/src/parsing/expander.c
+++ b/src/parsing/expander.c
@@ -1,82 +1,91 @@
 #include "../libft/libft.h"
 #include "minishell.h"
 
-static char	*append_exit_code(char *result, int *i, char *str, int *handled)
+static char     *append_exit_code(char *result, int *i, char *str, int *handled)
 {
-	char	*exit_code_str;
-	char	*tmp;
+        char    *exit_code_str;
+        char    *tmp;
 
-	*handled = 0;
-	if (!(str[*i] == '$' && str[*i + 1] == '?'))
-		return (result);
-	*handled = 1;
-	if (!(result = append_literal(result, str, 0, *i)))
-		return (NULL);
-	exit_code_str = ft_itoa(g_exit_code);
-	if (!exit_code_str)
-		return (free(result), NULL);
-	tmp = ft_strcatrealloc(result, exit_code_str);
-	free(exit_code_str);
-	if (!tmp)
-		return (free(result), NULL);
-	result = tmp;
-	*i += 2;
-	return (result);
+        *handled = 0;
+        if (!(str[*i] == '$' && str[*i + 1] == '?'))
+                return (result);
+        *handled = 1;
+        if (!(result = append_literal(result, str, 0, *i)))
+                return (NULL);
+        exit_code_str = ft_itoa(g_exit_code);
+        if (!exit_code_str)
+                return (free(result), NULL);
+        tmp = ft_strcatrealloc(result, exit_code_str);
+        free(exit_code_str);
+        if (!tmp)
+                return (free(result), NULL);
+        result = tmp;
+        *i += 2;
+        return (result);
 }
 
-static int	handle_exit_code_case(char **result, char *str, int *i, int *start)
+static int      handle_exit_code_case(char **result, char *str, int *i, int *start)
 {
-	int	handled;
+        int     handled;
 
-	*result = append_exit_code(*result, i, str, &handled);
-	if (*result && handled)
-	{
-		*start = *i;
-		return (1);
-	}
-	return (0);
+        *result = append_exit_code(*result, i, str, &handled);
+        if (*result && handled)
+        {
+                *start = *i;
+                return (1);
+        }
+        return (0);
 }
 
-static int	handle_env_var_case(char **result, char *str, int *i, int *start,
-		char **envp)
+static int      handle_env_var_case(char **result, char *str, int *i, int *start,
+                char **envp)
 {
-	if (ft_isalnum(str[*i + 1]))
-	{
-		if (!(*result = append_literal(*result, str, *start, *i)))
-			return (-1);
-		if (!(*result = append_expanded_var(*result, str, i, envp)))
-			return (-1);
-		*start = *i;
-		return (1);
-	}
-	return (0);
+        if (ft_isalnum(str[*i + 1]))
+        {
+                if (!(*result = append_literal(*result, str, *start, *i)))
+                        return (-1);
+                if (!(*result = append_expanded_var(*result, str, i, envp)))
+                        return (-1);
+                *start = *i;
+                return (1);
+        }
+        return (0);
 }
 
-char	*build_expanded_str(char *str, char **envp)
+char    *build_expanded_str(char *str, char **envp)
 {
-	int		i;
-	int		start;
-	char	*result;
-	int		env_result;
+        int             i;
+        int             start;
+        char            quote;
+        char            *result;
+        int             env_result;
 
-	i = 0;
-	start = 0;
-	result = NULL;
-	while (str[i])
-	{
-		if (str[i] == '$')
-		{
-			if (handle_exit_code_case(&result, str, &i, &start))
-				continue ;
-			env_result = handle_env_var_case(&result, str, &i, &start, envp);
-			if (env_result == -1)
-				return (NULL);
-			else if (env_result == 1)
-				continue ;
-		}
-		i++;
-	}
-	if (!(result = ft_strcatrealloc(result, str + start)))
-		return (NULL);
-	return (result);
+        i = 0;
+        start = 0;
+        quote = 0;
+        result = NULL;
+        while (str[i])
+        {
+                if (!quote && (str[i] == '\'' || str[i] == '"'))
+                        quote = str[i++];
+                else if (quote && str[i] == quote)
+                        quote = 0, i++;
+                else if (str[i] == '$' && quote != '\'')
+                {
+                        if (handle_exit_code_case(&result, str, &i, &start))
+                                continue ;
+                        env_result = handle_env_var_case(&result, str, &i, &start, envp);
+                        if (env_result == -1)
+                                return (NULL);
+                        else if (env_result == 1)
+                                continue ;
+                        i++;
+                }
+                else
+                        i++;
+        }
+        if (!(result = ft_strcatrealloc(result, str + start)))
+                return (NULL);
+        return (result);
 }
+

--- a/src/parsing/tokenize.c
+++ b/src/parsing/tokenize.c
@@ -13,118 +13,117 @@
 #include "../libft/libft.h"
 #include "minishell.h"
 
-static size_t	skip_token(char const *s, size_t i, char c)
+static size_t   skip_token(char const *s, size_t i, char c)
 {
-	char	quote;
+        char    quote;
 
-	quote = 0;
-	while (s[i])
-	{
-		if (!quote && (s[i] == '"' || s[i] == '\''))
-		{
-			quote = s[i++];
-			while (s[i] && s[i] != quote)
-				i++;
-			if (s[i] == quote)
-				i++;
-			quote = 0;
-			continue ;
-		}
-		if (!quote && s[i] == c)
-			break ;
-		i++;
-	}
-	return (i);
+        quote = 0;
+        while (s[i])
+        {
+                if (!quote && (s[i] == '"' || s[i] == '\''))
+                {
+                        quote = s[i++];
+                        while (s[i] && s[i] != quote)
+                                i++;
+                        if (s[i] == quote)
+                                i++;
+                        quote = 0;
+                        continue ;
+                }
+                if (!quote && s[i] == c)
+                        break ;
+                i++;
+        }
+        return (i);
 }
 
-static size_t	token_count(char const *s, char c)
+static size_t   token_count(char const *s, char c)
 {
-	size_t	i;
-	size_t	count;
+        size_t  i;
+        size_t  count;
 
-	i = 0;
-	count = 0;
-	while (s[i])
-	{
-		while (s[i] == c)
-			i++;
-		if (!s[i])
-			break ;
-		count++;
-		i = skip_token(s, i, c);
-	}
-	return (count);
+        i = 0;
+        count = 0;
+        while (s[i])
+        {
+                while (s[i] == c)
+                        i++;
+                if (!s[i])
+                        break ;
+                count++;
+                i = skip_token(s, i, c);
+        }
+        return (count);
 }
 
-static size_t	next_c(char *s, char c)
+static size_t   next_c(char *s, char c)
 {
-	size_t	len;
-	char	quote;
+        size_t  len;
+        char    quote;
 
-	len = 0;
-	quote = 0;
-	while (s[len])
-	{
-		if (!quote && (s[len] == '"' || s[len] == '\''))
-		{
-			quote = s[len++];
-			while (s[len] && s[len] != quote)
-				len++;
-			if (s[len] == quote)
-				len++;
-			quote = 0;
-			continue ;
-		}
-		if (!quote && s[len] == c)
-			break ;
-		len++;
-	}
-	return (len);
+        len = 0;
+        quote = 0;
+        while (s[len])
+        {
+                if (!quote && (s[len] == '"' || s[len] == '\''))
+                {
+                        quote = s[len++];
+                        while (s[len] && s[len] != quote)
+                                len++;
+                        if (s[len] == quote)
+                                len++;
+                        quote = 0;
+                        continue ;
+                }
+                if (!quote && s[len] == c)
+                        break ;
+                len++;
+        }
+        return (len);
 }
 
-static int	fill_arr_from_string(char const *s, char c, char **arr, char **envp)
+static int      fill_arr_from_string(char const *s, char c, char **arr, char **envp)
 {
-	int		i;
-	size_t	len;
-	char	*expanded;
+        int             i;
+        size_t  len;
+        char    *expanded;
 
-	i = 0;
-	while (*s)
-	{
-		while (*s == c)
-			s++;
-		if (!*s)
-			break ;
-		len = next_c((char *)s, c);
-		arr[i] = ft_substr((char *)s, 0, len);
-		if (!arr[i])
-			return (-1);
-		if (arr[i][0] != '\'')
-		{
-			expanded = build_expanded_str(arr[i], envp);
-			free(arr[i]);
-			arr[i] = expanded;
-		}
-		i++;
-		s += len;
-	}
-	return (i);
+        i = 0;
+        while (*s)
+        {
+                while (*s == c)
+                        s++;
+                if (!*s)
+                        break ;
+                len = next_c((char *)s, c);
+                arr[i] = ft_substr((char *)s, 0, len);
+                if (!arr[i])
+                        return (-1);
+                expanded = build_expanded_str(arr[i], envp);
+                free(arr[i]);
+                if (!expanded)
+                        return (-1);
+                arr[i] = expanded;
+                i++;
+                s += len;
+        }
+        return (i);
 }
 
-char	**tokenize_command(char const *s, char c, char **envp)
+char    **tokenize_command(char const *s, char c, char **envp, int **quoted)
 {
-	char	**arr;
-	int		i;
-	int		token_num;
+        char    **arr;
+        int             i;
+        int             token_num;
 
-	if (!s)
-		return (NULL);
-	arr = (char **)malloc((token_count(s, c) + 1) * sizeof(char *));
-	if (!arr)
-		return (NULL);
-	token_num = fill_arr_from_string(s, c, arr, envp);
-	if (token_num < 0)
-		return (free_cmd(arr), NULL);
+        if (!s)
+                return (NULL);
+        arr = (char **)malloc((token_count(s, c) + 1) * sizeof(char *));
+        if (!arr)
+                return (NULL);
+        token_num = fill_arr_from_string(s, c, arr, envp);
+        if (token_num < 0)
+                return (free_cmd(arr), NULL);
         arr[token_num] = NULL;
         arr = split_expanded_tokens(arr);
         if (!arr)
@@ -132,11 +131,17 @@ char	**tokenize_command(char const *s, char c, char **envp)
         arr = split_redirs(arr);
         if (!arr)
                 return (NULL);
-	i = 0;
-	while (arr[i])
-	{
-		remove_quotes(arr[i]);
-		i++;
-	}
-	return (arr);
+        token_num = count_strings(arr);
+        *quoted = malloc(sizeof(int) * token_num);
+        if (!*quoted)
+                return (free_cmd(arr), NULL);
+        i = 0;
+        while (i < token_num)
+        {
+                (*quoted)[i] = (ft_strchr(arr[i], '\'') || ft_strchr(arr[i], '"'));
+                remove_quotes(arr[i]);
+                i++;
+        }
+        return (arr);
 }
+

--- a/src/piping/pipeline.c
+++ b/src/piping/pipeline.c
@@ -12,108 +12,119 @@
 
 #include "minishell.h"
 
-static void	handle_input_redirection(int redir_in, int *in_fd)
+static void     handle_input_redirection(int redir_in, int *in_fd)
 {
-	if (redir_in != STDIN_FILENO)
-	{
-		if (redir_in < 0)
-		{
-			perror("Input redirection");
-			exit(1);
-		}
-		dup2(redir_in, STDIN_FILENO);
-		close(redir_in);
-	}
-	else if (*in_fd != STDIN_FILENO)
-	{
-		dup2(*in_fd, STDIN_FILENO);
-		close(*in_fd);
-	}
+        if (redir_in != STDIN_FILENO)
+        {
+                if (redir_in < 0)
+                {
+                        perror("Input redirection");
+                        exit(1);
+                }
+                dup2(redir_in, STDIN_FILENO);
+                close(redir_in);
+                if (*in_fd != STDIN_FILENO)
+                {
+                        close(*in_fd);
+                        *in_fd = STDIN_FILENO;
+                }
+        }
+        else if (*in_fd != STDIN_FILENO)
+        {
+                dup2(*in_fd, STDIN_FILENO);
+                close(*in_fd);
+        }
 }
 
-static void	handle_output_redirection(int redir_out, int *fd, int last)
+static void     handle_output_redirection(int redir_out, int *fd, int last)
 {
-	if (!last && redir_out == STDOUT_FILENO)
-	{
-		dup2(fd[1], STDOUT_FILENO);
-	}
-	else if (redir_out != STDOUT_FILENO)
-	{
-		if (redir_out < 0)
-		{
-			perror("Output redirection");
-			exit(1);
-		}
-		dup2(redir_out, STDOUT_FILENO);
-	}
+        if (!last && redir_out == STDOUT_FILENO)
+        {
+                dup2(fd[1], STDOUT_FILENO);
+        }
+        else if (redir_out != STDOUT_FILENO)
+        {
+                if (redir_out < 0)
+                {
+                        perror("Output redirection");
+                        exit(1);
+                }
+                dup2(redir_out, STDOUT_FILENO);
+        }
 }
 
-static void	child_process(char **envp, char **cmd, t_pipe_info pipe_info)
+static void     child_process(char **envp, char **cmd, int *quoted,
+                t_pipe_info pipe_info)
 {
-	int	redir_in;
-	int	redir_out;
+        int     redir_in;
+        int     redir_out;
 
-	redir_in = STDIN_FILENO;
-	redir_out = STDOUT_FILENO;
-	cmd = handle_redirections(cmd, count_strings(cmd) + 1, &redir_in,
-			&redir_out);
-	if (cmd == NULL)
-		exit(1);
-	handle_input_redirection(redir_in, &pipe_info.in_fd);
-	handle_output_redirection(redir_out, pipe_info.fd, pipe_info.last);
-	if (!pipe_info.last)
-	{
-		close(pipe_info.fd[0]);
-		close(pipe_info.fd[1]);
-	}
-	if (redir_out != STDOUT_FILENO)
-		close(redir_out);
-	execute_cmd(envp, cmd);
+        redir_in = STDIN_FILENO;
+        redir_out = STDOUT_FILENO;
+        cmd = handle_redirections(cmd, quoted, count_strings(cmd) + 1, envp,
+                        &redir_in, &redir_out);
+        free(quoted);
+        if (cmd == NULL)
+                exit(1);
+        handle_input_redirection(redir_in, &pipe_info.in_fd);
+        handle_output_redirection(redir_out, pipe_info.fd, pipe_info.last);
+        if (!pipe_info.last)
+        {
+                close(pipe_info.fd[0]);
+                close(pipe_info.fd[1]);
+        }
+        if (redir_out != STDOUT_FILENO)
+                close(redir_out);
+        execute_cmd(envp, cmd);
 }
 
-static int	pipeline_step(t_pipeline_data *pipeline, int *in_fd, int *fd, int i)
+static int      pipeline_step(t_pipeline_data *pipeline, int *in_fd, int *fd, int i)
 {
-	char		**cmd;
-	t_pipe_info	pipe_info;
+        char            **cmd;
+        int             *quoted;
+        t_pipe_info     pipe_info;
 
-	if (i < pipeline->nbr_segments - 1 && pipe(fd) == -1)
-	{
-		perror("pipe");
-		return (0);
-	}
-	cmd = tokenize_command(pipeline->segments[i], ' ', pipeline->envp);
-	if (!cmd || !cmd[0])
-	{
-		free_cmd(cmd);
-		if (i < pipeline->nbr_segments - 1)
-			close_pipe(fd);
-		return (1);
-	}
-	pipe_info.in_fd = *in_fd;
-	pipe_info.fd = fd;
-	pipe_info.last = (i == pipeline->nbr_segments - 1);
-	pipeline->pids[i] = fork();
-	if (pipeline->pids[i] == 0)
-		child_process(pipeline->envp, cmd, pipe_info);
-	free_cmd(cmd);
-	parent_cleanup(in_fd, fd, i, pipeline->nbr_segments);
-	return (1);
+        if (i < pipeline->nbr_segments - 1 && pipe(fd) == -1)
+        {
+                perror("pipe");
+                return (0);
+        }
+        cmd = tokenize_command(pipeline->segments[i], ' ', pipeline->envp, &quoted);
+        if (!cmd || !cmd[0])
+        {
+                free(quoted);
+                free_cmd(cmd);
+                if (i < pipeline->nbr_segments - 1)
+                        close_pipe(fd);
+                return (1);
+        }
+        pipe_info.in_fd = *in_fd;
+        pipe_info.fd = fd;
+        pipe_info.last = (i == pipeline->nbr_segments - 1);
+        pipeline->pids[i] = fork();
+        if (pipeline->pids[i] == 0)
+                child_process(pipeline->envp, cmd, quoted, pipe_info);
+        free_cmd(cmd);
+        free(quoted);
+        parent_cleanup(in_fd, fd, i, pipeline->nbr_segments);
+        return (1);
 }
 
-void	pipeline_loop(t_pipeline_data *pipeline)
+void    pipeline_loop(t_pipeline_data *pipeline)
 {
-	int	in_fd;
-	int	fd[2];
-	int	i;
+        int     in_fd;
+        int     fd[2];
+        int     i;
 
-	in_fd = STDIN_FILENO;
-	i = 0;
-	while (i < pipeline->nbr_segments)
-	{
-		if (!pipeline_step(pipeline, &in_fd, fd, i))
-			break ;
-		i++;
-	}
-	if (in_fd != STDIN_FILENO)
-		close(in_fd);
+        in_fd = STDIN_FILENO;
+        i = 0;
+        while (i < pipeline->nbr_segments)
+        {
+                if (!pipeline_step(pipeline, &in_fd, fd, i))
+                        break ;
+                i++;
+        }
+        if (in_fd != STDIN_FILENO)
+                close(in_fd);
 }
+

--- a/src/piping/redirections.c
+++ b/src/piping/redirections.c
@@ -14,123 +14,126 @@
 #include "minishell.h"
 #include <errno.h>
 
-int	open_infile(char *file, int *in_fd)
+int     open_infile(char *file, int *in_fd)
 {
-	int	fd;
+        int     fd;
 
-	fd = 0;
-	if (*in_fd != STDIN_FILENO)
-		close(*in_fd);
-	fd = open(file, O_RDONLY);
-	if (fd < 0)
-	{
-		perror(file);
-		if (errno == EACCES)
-			g_exit_code = 126;
-		else if (errno == ENOENT)
-			g_exit_code = 127;
-		else
-			g_exit_code = 1;
-		return (-1);
-	}
-	*in_fd = fd;
-	return (0);
+        fd = 0;
+        if (*in_fd != STDIN_FILENO)
+                close(*in_fd);
+        fd = open(file, O_RDONLY);
+        if (fd < 0)
+        {
+                perror(file);
+                if (errno == EACCES)
+                        g_exit_code = 126;
+                else if (errno == ENOENT)
+                        g_exit_code = 127;
+                else
+                        g_exit_code = 1;
+                return (-1);
+        }
+        *in_fd = fd;
+        return (0);
 }
 
-int	open_outfile(char *file, int *out_fd)
+int     open_outfile(char *file, int *out_fd)
 {
-	int	fd;
+        int     fd;
 
-	fd = 0;
-	if (*out_fd != STDOUT_FILENO)
-		close(*out_fd);
-	fd = open(file, O_WRONLY | O_CREAT | O_TRUNC, 0644);
-	if (fd < 0)
-	{
-		perror(file);
-		if (errno == EACCES)
-			g_exit_code = 126;
-		else
-			g_exit_code = 1;
-		return (-1);
-	}
-	*out_fd = fd;
-	return (0);
+        fd = 0;
+        if (*out_fd != STDOUT_FILENO)
+                close(*out_fd);
+        fd = open(file, O_WRONLY | O_CREAT | O_TRUNC, 0644);
+        if (fd < 0)
+        {
+                perror(file);
+                if (errno == EACCES)
+                        g_exit_code = 126;
+                else
+                        g_exit_code = 1;
+                return (-1);
+        }
+        *out_fd = fd;
+        return (0);
 }
 
-int	open_appendfile(char *file, int *out_fd)
+int     open_appendfile(char *file, int *out_fd)
 {
-	int	fd;
+        int     fd;
 
-	fd = 0;
-	if (*out_fd != STDOUT_FILENO)
-		close(*out_fd);
-	fd = open(file, O_WRONLY | O_CREAT | O_APPEND, 0644);
-	if (fd < 0)
-	{
-		perror(file);
-		if (errno == EACCES)
-			g_exit_code = 126;
-		else
-			g_exit_code = 1;
-		return (-1);
-	}
-	*out_fd = fd;
-	return (0);
+        fd = 0;
+        if (*out_fd != STDOUT_FILENO)
+                close(*out_fd);
+        fd = open(file, O_WRONLY | O_CREAT | O_APPEND, 0644);
+        if (fd < 0)
+        {
+                perror(file);
+                if (errno == EACCES)
+                        g_exit_code = 126;
+                else
+                        g_exit_code = 1;
+                return (-1);
+        }
+        *out_fd = fd;
+        return (0);
 }
 
-int	handle_redirection_logic(char **cmd, int *in_fd, int *out_fd, int *i)
+static int      handle_redirection_logic(char **cmd, int *quoted, char **envp,
+                int *in_fd, int *out_fd, int *i)
 {
-	if (!ft_strcmp(cmd[*i], "<") && cmd[*i + 1])
-	{
-		if (open_infile(cmd[*i + 1], in_fd) == -1)
-			return (-1);
-	}
-	else if (!ft_strcmp(cmd[*i], "<<") && cmd[*i + 1])
-	{
-		if (handle_heredoc(cmd[*i + 1], in_fd) == -1)
-			return (-1);
-	}
-	else if (!ft_strcmp(cmd[*i], ">") && cmd[*i + 1])
-	{
-		if (open_outfile(cmd[*i + 1], out_fd) == -1)
-			return (-1);
-	}
-	else if (!ft_strcmp(cmd[*i], ">>") && cmd[*i + 1])
-	{
-		if (open_appendfile(cmd[*i + 1], out_fd) == -1)
-			return (-1);
-	}
-	else
-		return (0);
-	(*i) += 2;
-	return (1);
+        if (!ft_strcmp(cmd[*i], "<") && cmd[*i + 1])
+        {
+                if (open_infile(cmd[*i + 1], in_fd) == -1)
+                        return (-1);
+        }
+        else if (!ft_strcmp(cmd[*i], "<<") && cmd[*i + 1])
+        {
+                if (handle_heredoc(cmd[*i + 1], quoted[*i + 1], envp, in_fd) == -1)
+                        return (-1);
+        }
+        else if (!ft_strcmp(cmd[*i], ">") && cmd[*i + 1])
+        {
+                if (open_outfile(cmd[*i + 1], out_fd) == -1)
+                        return (-1);
+        }
+        else if (!ft_strcmp(cmd[*i], ">>") && cmd[*i + 1])
+        {
+                if (open_appendfile(cmd[*i + 1], out_fd) == -1)
+                        return (-1);
+        }
+        else
+                return (0);
+        (*i) += 2;
+        return (1);
 }
 
-char	**handle_redirections(char **cmd, int count, int *in_fd, int *out_fd)
+char    **handle_redirections(char **cmd, int *quoted, int count, char **envp,
+                int *in_fd, int *out_fd)
 {
-	int		i;
-	int		j;
-	char	**clean;
-	int		res;
+        int             i;
+        int             j;
+        char    **clean;
+        int             res;
 
-	i = 0;
-	j = 0;
-	clean = malloc(sizeof(char *) * (count + 1));
-	if (!clean)
-		return (NULL);
-	while (cmd[i])
-	{
-		res = handle_redirection_logic(cmd, in_fd, out_fd, &i);
-		if (res == -1)
-		{
-			free(clean);
-			return (NULL);
-		}
-		else if (res == 0)
-			clean[j++] = cmd[i++];
-	}
-	clean[j] = NULL;
-	free(cmd);
-	return (clean);
+        i = 0;
+        j = 0;
+        clean = malloc(sizeof(char *) * (count + 1));
+        if (!clean)
+                return (NULL);
+        while (cmd[i])
+        {
+                res = handle_redirection_logic(cmd, quoted, envp, in_fd, out_fd, &i);
+                if (res == -1)
+                {
+                        free(clean);
+                        return (NULL);
+                }
+                else if (res == 0)
+                        clean[j++] = cmd[i++];
+        }
+        clean[j] = NULL;
+        free(cmd);
+        return (clean);
 }
+

--- a/src/piping/redirections_utils.c
+++ b/src/piping/redirections_utils.c
@@ -13,43 +13,60 @@
 #include "../libft/libft.h"
 #include "minishell.h"
 
-static int	open_heredoc(const char *delim)
+static int      open_heredoc(const char *delim, int quoted, char **envp)
 {
-	int		pipefd[2];
-	char	*line;
+        int             pipefd[2];
+        char    *line;
+        char    *expanded;
 
-	line = NULL;
-	if (pipe(pipefd) == -1)
-	{
-		perror("pipe");
-		g_exit_code = 1;
-		return (-1);
-	}
-	while (1)
-	{
-		line = readline("> ");
-		if (!line || ft_strcmp(line, delim) == 0)
-		{
-			free(line);
-			break ;
-		}
-		write(pipefd[1], line, ft_strlen(line));
-		write(pipefd[1], "\n", 1);
-		free(line);
-	}
-	close(pipefd[1]);
-	return (pipefd[0]);
+        line = NULL;
+        if (pipe(pipefd) == -1)
+        {
+                perror("pipe");
+                g_exit_code = 1;
+                return (-1);
+        }
+        while (1)
+        {
+                line = readline("> ");
+                if (!line || ft_strcmp(line, delim) == 0)
+                {
+                        free(line);
+                        break ;
+                }
+                if (!quoted)
+                {
+                        expanded = build_expanded_str(line, envp);
+                        free(line);
+                        if (!expanded)
+                        {
+                                close(pipefd[1]);
+                                return (-1);
+                        }
+                        write(pipefd[1], expanded, ft_strlen(expanded));
+                        free(expanded);
+                }
+                else
+                {
+                        write(pipefd[1], line, ft_strlen(line));
+                        free(line);
+                }
+                write(pipefd[1], "\n", 1);
+        }
+        close(pipefd[1]);
+        return (pipefd[0]);
 }
 
-int	handle_heredoc(const char *delim, int *in_fd)
+int     handle_heredoc(const char *delim, int quoted, char **envp, int *in_fd)
 {
-	int	h;
+        int     h;
 
-	h = open_heredoc(delim);
-	if (h < 0)
-		return (-1);
-	if (*in_fd != STDIN_FILENO)
-		close(*in_fd);
-	*in_fd = h;
-	return (0);
+        h = open_heredoc(delim, quoted, envp);
+        if (h < 0)
+                return (-1);
+        if (*in_fd != STDIN_FILENO)
+                close(*in_fd);
+        *in_fd = h;
+        return (0);
 }
+


### PR DESCRIPTION
## Summary
- Respect quote boundaries when expanding variables and capture quoting metadata for tokens
- Preserve heredoc delimiter quoting and expand heredoc lines only when the delimiter is unquoted
- Close unused pipeline read ends after redirecting stdin during pipelines

## Testing
- `make`


------
https://chatgpt.com/codex/tasks/task_e_68a5ac268cc4832586e2dd46d2a74218