### PR TITLE
Handle absolute paths in pipeline execution

### DIFF
--- a/src/piping/pipeline_utils.c
+++ b/src/piping/pipeline_utils.c
@@ -11,6 +11,7 @@
 /* ************************************************************************** */
 
 #include "minishell.h"
+#include "../libft/libft.h"
 
 void	execute_pipeline(char **envp, char **segments)
 {
@@ -19,39 +20,66 @@ void	execute_pipeline(char **envp, char **segments)
 	pipeline.envp = envp;
 	pipeline.segments = segments;
 	pipeline.nbr_segments = count_strings(segments);
-	pipeline.pids = malloc(sizeof(pid_t) * pipeline.nbr_segments);
-	if (!pipeline.pids)
-		return ;
+        pipeline.pids = ft_calloc(pipeline.nbr_segments, sizeof(pid_t));
+        if (!pipeline.pids)
+                return ;
 	pipeline_loop(&pipeline);
 	wait_for_all(pipeline.pids, pipeline.nbr_segments);
 	free(pipeline.pids);
 }
 
-void	execute_cmd(char **envp, char **cmd)
+void    execute_cmd(char **envp, char **cmd)
 {
-	char	*path;
+        char    *path;
 
-	if (is_builtin(cmd[0]))
-	{
-		run_builtin(&envp, cmd);
-		free_cmd(cmd);
-		exit(g_exit_code);
-	}
-	path = get_path(envp, cmd);
-	if (path)
-	{
-		execve(path, cmd, envp);
-		perror("execve");
-		free(path);
-		g_exit_code = 126;
-	}
-	else
-	{
-		fprintf(stderr, "Command not found: %s\n", cmd[0]);
-		g_exit_code = 127;
-	}
-	free_cmd(cmd);
-	exit(g_exit_code);
+        if (is_builtin(cmd[0]))
+        {
+                run_builtin(&envp, cmd);
+                free_cmd(cmd);
+                exit(g_exit_code);
+        }
+        if (ft_strchr(cmd[0], '/'))
+        {
+                if (access(cmd[0], F_OK) != 0)
+                {
+                        perror(cmd[0]);
+                        g_exit_code = 127;
+                }
+                else if (is_folder(cmd[0]))
+                {
+                        fprintf(stderr, "%s: Is a directory\n", cmd[0]);
+                        g_exit_code = 126;
+                }
+                else if (access(cmd[0], X_OK) != 0)
+                {
+                        perror(cmd[0]);
+                        g_exit_code = 126;
+                }
+                else
+                {
+                        execve(cmd[0], cmd, envp);
+                        perror("execve");
+                        g_exit_code = 126;
+                }
+        }
+        else
+        {
+                path = get_path(envp, cmd);
+                if (path)
+                {
+                        execve(path, cmd, envp);
+                        perror("execve");
+                        free(path);
+                        g_exit_code = 126;
+                }
+                else
+                {
+                        fprintf(stderr, "%s: command not found\n", cmd[0]);
+                        g_exit_code = 127;
+                }
+        }
+        free_cmd(cmd);
+        exit(g_exit_code);
 }
 
 void	close_pipe(int *fd)
@@ -76,20 +104,20 @@ void	wait_for_all(pid_t *pids, int count)
 	int	i;
 	int	status;
 
-	i = 0;
-	while (i < count)
-	{
-		if (waitpid(pids[i], &status, 0) == -1)
-			perror("waitpid");
-		if (i == count - 1)
-		{
-			if (WIFEXITED(status))
-				g_exit_code = WEXITSTATUS(status);
-			else if (WIFSIGNALED(status))
-				g_exit_code = 128 + WTERMSIG(status);
-			else
-				g_exit_code = 1;
-		}
-		i++;
-	}
+        i = 0;
+        while (i < count)
+        {
+                if (pids[i] > 0)
+                {
+                        if (waitpid(pids[i], &status, 0) == -1)
+                                perror("waitpid");
+                        else if (WIFEXITED(status))
+                                g_exit_code = WEXITSTATUS(status);
+                        else if (WIFSIGNALED(status))
+                                g_exit_code = 128 + WTERMSIG(status);
+                        else
+                                g_exit_code = 1;
+                }
+                i++;
+        }
 }


### PR DESCRIPTION
## Summary
- handle commands containing '/' in the pipeline by checking for existence, directory type, and executability before execve
- fall back to PATH lookup only when '/' is absent
- preserve the last pipeline segment's exit status when waiting for child processes

## Testing
- `make`


------
https://chatgpt.com/codex/tasks/task_e_68a5c0dff1608325bbc7d6e08450a744