### PR TITLE
Handle literal quotes in minishell argument parsing

### DIFF
--- a/src/handlers.c
+++ b/src/handlers.c
@@ -51,9 +51,13 @@ char **prepare_argv_from_tokens(t_token **tokens)
         argv[i] = ft_strdup(tokens[i]->str);
         if (!argv[i])
             return (free_cmd(argv), NULL);
-
-        // finally strip quotes now
-        remove_quotes(argv[i]);
+        /*
+         * Quotes that affected tokenisation have already been removed during
+         * parsing.  Any remaining quotes in the token are meant to be literal
+         * characters (e.g. the command `echo '"$USER"'` should pass the
+         * string "\"$USER\"" to echo).  Stripping quotes here would modify
+         * the intended argument and lead to behaviour that differs from Bash.
+         */
     }
     argv[count] = NULL;
     return argv;

--- a/src/parsing/expander_utils.c
+++ b/src/parsing/expander_utils.c
@@ -1,18 +1,30 @@
 #include "../libft/libft.h"
 #include "minishell.h"
 
-// Only removes surrounding quotes if both ends match
+// Remove all quoting characters that affected parsing while preserving
+// characters that were meant to be literal (e.g. quotes inside single quotes).
 void remove_quotes(char *str)
 {
-    size_t len = ft_strlen(str);
+    char    quote;
+    size_t  i;
+    size_t  j;
 
-    if (len >= 2 &&
-        ((str[0] == '"' && str[len - 1] == '"') ||
-         (str[0] == '\'' && str[len - 1] == '\'')))
+    quote = 0;
+    i = 0;
+    j = 0;
+    while (str[i])
     {
-        memmove(str, str + 1, len - 2);  // shift left
-        str[len - 2] = '\0';
+        if (!quote && (str[i] == '\'' || str[i] == '"'))
+            quote = str[i++];
+        else if (quote && str[i] == quote)
+        {
+            quote = 0;
+            i++;
+        }
+        else
+            str[j++] = str[i++];
     }
+    str[j] = '\0';
 }
 
 


### PR DESCRIPTION
## Summary
- avoid stripping quotes twice when building argument vector
- expand variables before removing syntactic quotes
- handle nested quote removal while preserving literal quotes

## Testing
- `make`
- `/bin/echo '"$USER"'` (bash vs. minishell)
- `/bin/echo "'$USER'"` (bash vs. minishell)
- `/bin/echo ""'$USER'""` (bash vs. minishell)


------
https://chatgpt.com/codex/tasks/task_e_68ac3b234fa083258d5e3dd345730552