### PR TITLE
Handle literal quotes in minishell argument parsing

### DIFF
--- a/src/handlers.c
+++ b/src/handlers.c
@@ -51,9 +51,13 @@ char **prepare_argv_from_tokens(t_token **tokens)
         argv[i] = ft_strdup(tokens[i]->str);
         if (!argv[i])
             return (free_cmd(argv), NULL);
-
-        // finally strip quotes now
-        remove_quotes(argv[i]);
+        /*
+         * Quotes that affected tokenisation have already been removed during
+         * parsing.  Any remaining quotes in the token are meant to be literal
+         * characters (e.g. the command `echo '"$USER"'` should pass the
+         * string "\"$USER\"" to echo).  Stripping quotes here would modify
+         * the intended argument and lead to behaviour that differs from Bash.
+         */
     }
     argv[count] = NULL;
     return argv;

--- a/src/parsing/expander_utils.c
+++ b/src/parsing/expander_utils.c
@@ -1,18 +1,30 @@
 #include "../libft/libft.h"
 #include "minishell.h"
 
-// Only removes surrounding quotes if both ends match
+// Remove all quoting characters that affected parsing while preserving
+// characters that were meant to be literal (e.g. quotes inside single quotes).
 void remove_quotes(char *str)
 {
-    size_t len = ft_strlen(str);
+    char    quote;
+    size_t  i;
+    size_t  j;
 
-    if (len >= 2 &&
-        ((str[0] == '"' && str[len - 1] == '"') ||
-         (str[0] == '\'' && str[len - 1] == '\'')))
+    quote = 0;
+    i = 0;
+    j = 0;
+    while (str[i])
     {
-        memmove(str, str + 1, len - 2);  // shift left
-        str[len - 2] = '\0';
+        if (!quote && (str[i] == '\'' || str[i] == '"'))
+            quote = str[i++];
+        else if (quote && str[i] == quote)
+        {
+            quote = 0;
+            i++;
+        }
+        else
+            str[j++] = str[i++];
     }
+    str[j] = '\0';
 }
 
 

--- a/src/parsing/tokenize.c
+++ b/src/parsing/tokenize.c
@@ -13,6 +13,32 @@
 #include "../libft/libft.h"
 #include "minishell.h"
 
+static int  fully_quoted(const char *s)
+{
+    size_t  len;
+    size_t  i;
+    char    quote;
+
+    if (!s)
+        return (0);
+    len = ft_strlen(s);
+    if (len < 2)
+        return (0);
+    quote = s[0];
+    if ((quote != '\'' && quote != '"') || s[len - 1] != quote)
+        return (0);
+    i = 1;
+    while (i < len - 1)
+    {
+        if (s[i] == quote)
+            return (0);
+        i++;
+    }
+    if (quote == '\'')
+        return (1);
+    return (2);
+}
+
 static size_t skip_token(const char *s, size_t i, char c)
 {
     char quote = 0;
@@ -77,15 +103,15 @@ static size_t next_c(const char *s, char c)
     return i;
 }
 
-static t_token **fill_arr_from_string(const char *s, char c, char **envp)
+static t_token **fill_arr_from_string(const char *s, char c)
 {
     t_token **arr;
     int token_num;
     int i;
     size_t len;
-    char *expanded;
     int type;
     int quoted;
+    char *substr;
 
     token_num = token_count(s, c);
     arr = malloc(sizeof(t_token *) * (token_num + 1));
@@ -101,29 +127,12 @@ static t_token **fill_arr_from_string(const char *s, char c, char **envp)
             break;
 
         len = next_c(s, c);
-        char *substr = ft_substr(s, 0, len);
+        substr = ft_substr(s, 0, len);
         if (!substr)
             return (free_tokens(arr), NULL);
 
-        // detect quotes
-        quoted = 0;
-        if (substr[0] == '\'' && substr[ft_strlen(substr) - 1] == '\'')
-            quoted = 1;
-        else if (substr[0] == '"' && substr[ft_strlen(substr) - 1] == '"')
-            quoted = 2;
-
-        // strip quotes before expansion
-        remove_quotes(substr);
-
-        // expand unless single-quoted
-        if (quoted != 1)
-        {
-            expanded = build_expanded_str(substr, envp);
-            free(substr);
-            if (!expanded)
-                return (free_tokens(arr), NULL);
-            substr = expanded;
-        }
+        // detect if the whole token is wrapped in a single pair of quotes
+        quoted = fully_quoted(substr);
 
         type = 0;
         arr[i++] = new_token(substr, quoted, type);
@@ -143,7 +152,7 @@ t_token **tokenize_command(char const *s, char c, char **envp)
     if (!s)
         return NULL;
 
-    arr = fill_arr_from_string(s, c, envp);
+    arr = fill_arr_from_string(s, c);
     if (!arr)
         return NULL;
 
@@ -160,6 +169,8 @@ t_token **tokenize_command(char const *s, char c, char **envp)
             free(arr[i]->str);
             arr[i]->str = expanded;
         }
+        // remove surrounding quotes after expansion (or for single quotes)
+        remove_quotes(arr[i]->str);
     }
 
     // 3. Split expansions if needed


### PR DESCRIPTION
## Summary
- avoid stripping quotes twice when building argument vector
- expand variables before removing syntactic quotes
- handle nested quote removal while preserving literal quotes
- correctly detect fully quoted tokens so mixed quotes allow expansion

## Testing
- `make`
- `/bin/echo '"'$USER'"'` (bash)
- `/bin/echo '"'$USER'"'` (minishell)


------
https://chatgpt.com/codex/tasks/task_e_68ac3b234fa083258d5e3dd345730552