### PR TITLE
fix: handle redirections in quoted tokens

### DIFF
--- a/src/parsing/redir_split.c
+++ b/src/parsing/redir_split.c
@@ -1,39 +1,41 @@
 #include "../libft/libft.h"
 #include "minishell.h"
 
-static int	part_count(char *tok)
+static int part_count(t_token *tok)
 {
-	int	i;
-	int	start;
-	int	count;
+    int i;
+    int start;
+    int count;
 
-	i = 0;
-	start = 0;
-	count = 0;
-	while (tok[i])
-	{
-		if (tok[i] == '>' || tok[i] == '<')
-		{
-			if (i - start > 0)
-				count++;
-			if (tok[i] == '>' && tok[i + 1] == '>')
-			{
-				count++;
-				i += 2;
-			}
-			else
-			{
-				count++;
-				i++;
-			}
-			start = i;
-		}
-		else
-			i++;
-	}
-	if (i - start > 0)
-		count++;
-	return (count);
+    if (tok->quoted)
+        return (1);
+    i = 0;
+    start = 0;
+    count = 0;
+    while (tok->str[i])
+    {
+        if (tok->str[i] == '>' || tok->str[i] == '<')
+        {
+            if (i - start > 0)
+                count++;
+            if (tok->str[i] == '>' && tok->str[i + 1] == '>')
+            {
+                count++;
+                i += 2;
+            }
+            else
+            {
+                count++;
+                i++;
+            }
+            start = i;
+        }
+        else
+            i++;
+    }
+    if (i - start > 0)
+        count++;
+    return (count);
 }
 
 static int total_parts(t_token **arr)
@@ -45,17 +47,19 @@ static int total_parts(t_token **arr)
     i = 0;
     while (arr && arr[i])
     {
-        total += part_count(arr[i]->str);
+        total += part_count(arr[i]);
         i++;
     }
     return (total);
 }
 
-
 t_token **split_redirs(t_token **arr)
 {
     t_token **out;
-    int i, j, idx, start;
+    int i;
+    int j;
+    int idx;
+    int start;
     char quote;
 
     out = malloc(sizeof(t_token *) * (total_parts(arr) + 1));
@@ -66,6 +70,11 @@ t_token **split_redirs(t_token **arr)
     i = 0;
     while (arr[i])
     {
+        if (arr[i]->quoted)
+        {
+            out[idx++] = arr[i++];
+            continue;
+        }
         j = 0;
         start = 0;
         quote = 0;
@@ -81,12 +90,12 @@ t_token **split_redirs(t_token **arr)
                 if (j - start > 0)
                     out[idx++] = new_token(ft_substr(arr[i]->str, start, j - start),
                                            arr[i]->quoted, 0);
-                if (arr[i]->str[j] == '>' && arr[i]->str[j+1] == '>')
+                if (arr[i]->str[j] == '>' && arr[i]->str[j + 1] == '>')
                 {
                     out[idx++] = new_token(ft_strdup(">>"), 0, 1);
                     j += 2;
                 }
-                else if (arr[i]->str[j] == '<' && arr[i]->str[j+1] == '<')
+                else if (arr[i]->str[j] == '<' && arr[i]->str[j + 1] == '<')
                 {
                     out[idx++] = new_token(ft_strdup("<<"), 0, 2);
                     j += 2;
@@ -117,4 +126,3 @@ t_token **split_redirs(t_token **arr)
     free(arr);
     return (out);
 }
-


### PR DESCRIPTION
## Summary
- avoid splitting redirection operators when a token was originally quoted

## Testing
- `make`
- `echo '/bin/echo "cat lol.c | cat > lol.c"' | ./minishell`


------
https://chatgpt.com/codex/tasks/task_e_68ac53d3f6dc8325bb01b9ab59690901