### PR TITLE
Handle tab whitespace and fix append redirection

### DIFF
--- a/src/parsing/redir_split.c
+++ b/src/parsing/redir_split.c
@@ -92,7 +92,7 @@ t_token **split_redirs(t_token **arr)
                                            arr[i]->quoted, 0);
                 if (arr[i]->str[j] == '>' && arr[i]->str[j + 1] == '>')
                 {
-                    out[idx++] = new_token(ft_strdup(">>"), 0, 1);
+                    out[idx++] = new_token(ft_strdup(">>"), 0, 4);
                     j += 2;
                 }
                 else if (arr[i]->str[j] == '<' && arr[i]->str[j + 1] == '<')
@@ -107,7 +107,7 @@ t_token **split_redirs(t_token **arr)
                 }
                 else
                 {
-                    out[idx++] = new_token(ft_strdup("<"), 0, 4);
+                    out[idx++] = new_token(ft_strdup("<"), 0, 1);
                     j++;
                 }
                 start = j;

--- a/src/parsing/tokenize.c
+++ b/src/parsing/tokenize.c
@@ -38,6 +38,13 @@ static int  fully_quoted(const char *s)
     return (2);
 }
 
+static int  is_delim(char ch, char delim)
+{
+    if (delim == ' ')
+        return (ch == ' ' || ch == '\t');
+    return (ch == delim);
+}
+
 static size_t skip_token(const char *s, size_t i, char c)
 {
     char quote = 0;
@@ -54,7 +61,7 @@ static size_t skip_token(const char *s, size_t i, char c)
             quote = 0;
             continue;
         }
-        if (!quote && s[i] == c)
+        if (!quote && is_delim(s[i], c))
             break;
         i++;
     }
@@ -68,7 +75,7 @@ static size_t token_count(const char *s, char c)
 
     while (s[i])
     {
-        while (s[i] == c)
+        while (is_delim(s[i], c))
             i++;
         if (!s[i])
             break;
@@ -95,7 +102,7 @@ static size_t next_c(const char *s, char c)
             quote = 0;
             continue;
         }
-        if (!quote && s[i] == c)
+        if (!quote && is_delim(s[i], c))
             break;
         i++;
     }
@@ -120,7 +127,7 @@ static t_token **fill_arr_from_string(const char *s, char c)
     i = 0;
     while (*s)
     {
-        while (*s == c)
+        while (is_delim(*s, c))
             s++;
         if (!*s)
             break;

--- a/src/parsing/word_split.c
+++ b/src/parsing/word_split.c
@@ -1,6 +1,50 @@
 #include "../libft/libft.h"
 #include "minishell.h"
 
+static int  is_whitespace(char c)
+{
+    return (c == ' ' || c == '\t');
+}
+
+static char **split_whitespace(const char *s)
+{
+    int i = 0;
+    int start;
+    int k = 0;
+    char **out;
+
+    int count = 0;
+    while (s[i])
+    {
+        while (is_whitespace(s[i]))
+            i++;
+        if (!s[i])
+            break;
+        count++;
+        while (s[i] && !is_whitespace(s[i]))
+            i++;
+    }
+
+    out = malloc(sizeof(char *) * (count + 1));
+    if (!out)
+        return (NULL);
+
+    i = 0;
+    while (s[i])
+    {
+        while (is_whitespace(s[i]))
+            i++;
+        if (!s[i])
+            break;
+        start = i;
+        while (s[i] && !is_whitespace(s[i]))
+            i++;
+        out[k++] = ft_substr(s, start, i - start);
+    }
+    out[k] = NULL;
+    return (out);
+}
+
 t_token **split_expanded_tokens(t_token **arr)
 {
     int i, j, k, total;
@@ -15,7 +59,7 @@ t_token **split_expanded_tokens(t_token **arr)
             total++;
         else
         {
-            parts = ft_split(arr[i]->str, ' ');
+            parts = split_whitespace(arr[i]->str);
             if (!parts)
                 return (free_tokens(arr), NULL);
             total += count_strings(parts);
@@ -38,7 +82,7 @@ t_token **split_expanded_tokens(t_token **arr)
         }
         else
         {
-            parts = ft_split(arr[i]->str, ' ');
+            parts = split_whitespace(arr[i]->str);
             free(arr[i]->str);
             free(arr[i]);
             if (!parts)


### PR DESCRIPTION
## Summary
- treat tabs as delimiters during tokenization and word splitting so echo collapses whitespace like bash
- correct redirection token types so appending to new files (e.g. `>> '$USER'`) no longer crashes

## Testing
- `make clean >/dev/null && make >/dev/null`
- `./minishell <<'EOF'
echo one      two
>> '$USER'
ls
exit
EOF`


------
https://chatgpt.com/codex/tasks/task_e_68ac65a922b0832592530ad6ca7607e7