### PR TITLE
Continue pipeline after redirection errors

### DIFF
--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -49,6 +49,15 @@ typedef struct s_token
     int     type;       // e.g. WORD, REDIR_IN, REDIR_OUT, HEREDOC, PIPE
 }   t_token;
 
+typedef struct s_command
+{
+    t_token **tokens;
+    int     in_fd;
+    int     out_fd;
+    int     cmd_type;
+    int     has_heredoc;
+}   t_command;
+
 // Pipe data
 typedef struct s_pipeline_data
 {
@@ -56,6 +65,7 @@ typedef struct s_pipeline_data
 	char **segments;
 	pid_t *pids;
 	int nbr_segments;
+	t_command *cmds;
 }	t_pipeline_data;
 
 typedef struct s_pipe_info

--- a/src/piping/pipeline.c
+++ b/src/piping/pipeline.c
@@ -6,7 +6,7 @@
 /*   By: dimendon <dimendon@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/08/05 13:39:33 by dimendon          #+#    #+#             */
-/*   Updated: 2025/08/25 11:23:18 by dimendon         ###   ########.fr       */
+/*   Updated: 2025/08/26 16:00:00 by dimendon         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -53,24 +53,10 @@ static void     handle_output_redirection(int redir_out, int *fd, int last)
         }
 }
 
-static void child_process(char **envp, char *segment, t_pipe_info pipe_info)
+static void child_process(char **envp, t_command *cmd, t_pipe_info pipe_info)
 {
-    int redir_in = STDIN_FILENO;
-    int redir_out = STDOUT_FILENO;
-
-    // Tokenize input line
-    t_token **cmd = tokenize_command(segment, ' ', envp);
-    if (!cmd)
-        exit(1);
-
-    // Handle <, >, <<, >>
-    cmd = handle_redirections(cmd, envp, &redir_in, &redir_out);
-    if (!cmd)
-        exit(1);
-
-    // Setup input/output redirection
-    handle_input_redirection(redir_in, &pipe_info.in_fd);
-    handle_output_redirection(redir_out, pipe_info.fd, pipe_info.last);
+    handle_input_redirection(cmd->in_fd, &pipe_info.in_fd);
+    handle_output_redirection(cmd->out_fd, pipe_info.fd, pipe_info.last);
 
     if (!pipe_info.last)
     {
@@ -78,11 +64,8 @@ static void child_process(char **envp, char *segment, t_pipe_info pipe_info)
         close(pipe_info.fd[1]);
     }
 
-    // Execute command
-    execute_cmd(envp, cmd);
-
-    free_tokens(cmd);
-    exit(0); // make sure child exits
+    execute_cmd(envp, cmd->tokens);
+    exit(0);
 }
 
 static int pipeline_step(t_pipeline_data *pipeline, int *in_fd, int *fd, int i)
@@ -99,12 +82,14 @@ static int pipeline_step(t_pipeline_data *pipeline, int *in_fd, int *fd, int i)
     pipe_info.fd = fd;
     pipe_info.last = (i == pipeline->nbr_segments - 1);
 
-    pipeline->pids[i] = fork();
-    if (pipeline->pids[i] == 0)
+    if (pipeline->cmds[i].tokens)
     {
-        // Child takes care of tokenizing the segment
-        child_process(pipeline->envp, pipeline->segments[i], pipe_info);
+        pipeline->pids[i] = fork();
+        if (pipeline->pids[i] == 0)
+            child_process(pipeline->envp, &pipeline->cmds[i], pipe_info);
     }
+    else
+        pipeline->pids[i] = -1;
 
     // Parent cleanup
     parent_cleanup(in_fd, fd, i, pipeline->nbr_segments);

--- a/src/piping/pipeline_utils.c
+++ b/src/piping/pipeline_utils.c
@@ -6,7 +6,7 @@
 /*   By: dimendon <dimendon@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/08/05 13:39:38 by dimendon          #+#    #+#             */
-/*   Updated: 2025/08/25 11:53:10 by dimendon         ###   ########.fr       */
+/*   Updated: 2025/08/26 16:00:00 by dimendon         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,24 +14,86 @@
 #include "../libft/libft.h"
 #include <errno.h>
 
-void	execute_pipeline(char **envp, char **segments)
+static void cleanup_commands(t_pipeline_data *pipeline, int count)
 {
-	t_pipeline_data	pipeline;
-
-	pipeline.envp = envp;
-	pipeline.segments = segments;
-	pipeline.nbr_segments = count_strings(segments);
-        pipeline.pids = ft_calloc(pipeline.nbr_segments, sizeof(pid_t));
-        if (!pipeline.pids)
-        {
-                g_exit_code = 1;
-                return ;
-        }
-	pipeline_loop(&pipeline);
-	wait_for_all(pipeline.pids, pipeline.nbr_segments);
-	free(pipeline.pids);
+    int i = 0;
+    while (i < count)
+    {
+        if (pipeline->cmds[i].in_fd != STDIN_FILENO)
+            close(pipeline->cmds[i].in_fd);
+        if (pipeline->cmds[i].out_fd != STDOUT_FILENO)
+            close(pipeline->cmds[i].out_fd);
+        free_tokens(pipeline->cmds[i].tokens);
+        i++;
+    }
+    free(pipeline->cmds);
 }
 
+void    execute_pipeline(char **envp, char **segments)
+{
+    t_pipeline_data pipeline;
+    int             i;
+
+    pipeline.envp = envp;
+    pipeline.segments = segments;
+    pipeline.nbr_segments = count_strings(segments);
+    pipeline.cmds = ft_calloc(pipeline.nbr_segments, sizeof(t_command));
+    if (!pipeline.cmds)
+    {
+        g_exit_code = 1;
+        return ;
+    }
+    i = 0;
+    while (i < pipeline.nbr_segments)
+    {
+        pipeline.cmds[i].in_fd = STDIN_FILENO;
+        pipeline.cmds[i].out_fd = STDOUT_FILENO;
+        pipeline.cmds[i].cmd_type = 0;
+        pipeline.cmds[i].has_heredoc = 0;
+        pipeline.cmds[i].tokens = tokenize_command(segments[i], ' ', envp);
+        if (!pipeline.cmds[i].tokens)
+        {
+            cleanup_commands(&pipeline, i);
+            g_exit_code = 1;
+            return ;
+        }
+        int t = 0;
+        while (pipeline.cmds[i].tokens[t])
+        {
+            if (pipeline.cmds[i].tokens[t]->type == 2)
+                pipeline.cmds[i].has_heredoc = 1;
+            t++;
+        }
+        pipeline.cmds[i].tokens = handle_redirections(pipeline.cmds[i].tokens,
+                envp, &pipeline.cmds[i].in_fd, &pipeline.cmds[i].out_fd);
+        if (!pipeline.cmds[i].tokens)
+        {
+            if (pipeline.cmds[i].in_fd != STDIN_FILENO)
+                close(pipeline.cmds[i].in_fd);
+            if (pipeline.cmds[i].out_fd != STDOUT_FILENO)
+                close(pipeline.cmds[i].out_fd);
+            pipeline.cmds[i].in_fd = STDIN_FILENO;
+            pipeline.cmds[i].out_fd = STDOUT_FILENO;
+            pipeline.cmds[i].cmd_type = 0;
+            i++;
+            continue;
+        }
+        if (pipeline.cmds[i].tokens[0])
+            pipeline.cmds[i].cmd_type = is_builtin(pipeline.cmds[i].tokens[0]->str);
+        i++;
+    }
+    pipeline.pids = ft_calloc(pipeline.nbr_segments, sizeof(pid_t));
+    if (!pipeline.pids)
+    {
+        cleanup_commands(&pipeline, pipeline.nbr_segments);
+        g_exit_code = 1;
+        return ;
+    }
+    pipeline_loop(&pipeline);
+    wait_for_all(pipeline.pids, pipeline.nbr_segments);
+    cleanup_commands(&pipeline, pipeline.nbr_segments);
+    free(pipeline.pids);
+}
 static int      exit_code_from_errno(void)
 {
         if (errno == ENOENT)


### PR DESCRIPTION
## Summary
- keep pipeline setup when a segment's redirection fails by clearing its descriptors and marking it invalid
- skip forking invalid segments while still wiring pipes so later commands run

## Testing
- `make`
- `echo "echo hi >.outfiles/outfile01 | echo bye" | ./minishell`


------
https://chatgpt.com/codex/tasks/task_e_68adb7e5f15483259d874cd5b0e94400