### PR TITLE
refactor: remove for loops and ternary operators

### DIFF
--- a/src/builtins/custom_cd.c
+++ b/src/builtins/custom_cd.c
@@ -18,7 +18,10 @@ t_token *make_token(char *str)
     t_token *tok = malloc(sizeof(t_token));
     if (!tok)
         return (NULL);
-    tok->str = (str ? ft_strdup(str) : NULL);
+    if (str)
+        tok->str = ft_strdup(str);
+    else
+        tok->str = NULL;
     tok->type = 0;
     return tok;
 }

--- a/src/handlers.c
+++ b/src/handlers.c
@@ -46,7 +46,8 @@ char **prepare_argv_from_tokens(t_token **tokens)
     if (!argv)
         return (NULL);
 
-    for (int i = 0; i < count; i++)
+    int i = 0;
+    while (i < count)
     {
         argv[i] = ft_strdup(tokens[i]->str);
         if (!argv[i])
@@ -58,6 +59,7 @@ char **prepare_argv_from_tokens(t_token **tokens)
          * string "\"$USER\"" to echo).  Stripping quotes here would modify
          * the intended argument and lead to behaviour that differs from Bash.
          */
+        i++;
     }
     argv[count] = NULL;
     return argv;

--- a/src/parsing/tokenize.c
+++ b/src/parsing/tokenize.c
@@ -166,7 +166,8 @@ t_token **tokenize_command(char const *s, char c, char **envp)
     if (!arr)
         return NULL;
 
-    for (i = 0; arr[i]; i++)
+    i = 0;
+    while (arr[i])
     {
         if (arr[i]->quoted != 1)
         {
@@ -179,8 +180,9 @@ t_token **tokenize_command(char const *s, char c, char **envp)
             free(arr[i]->str);
             arr[i]->str = expanded;
         }
-    if (ft_strchr(arr[i]->str, '"') || ft_strchr(arr[i]->str, '\''))
-        remove_quotes(arr[i]->str);
+        if (ft_strchr(arr[i]->str, '"') || ft_strchr(arr[i]->str, '\''))
+            remove_quotes(arr[i]->str);
+        i++;
     }
     arr = split_expanded_tokens(arr);
     if (!arr)

--- a/src/piping/pipeline_utils.c
+++ b/src/piping/pipeline_utils.c
@@ -111,8 +111,12 @@ char **tokens_to_argv(t_token **cmd)
     if (!argv)
         return NULL;
 
-    for (int i = 0; i < count; i++)
+    int i = 0;
+    while (i < count)
+    {
         argv[i] = ft_strdup(cmd[i]->str); // duplicate string from token
+        i++;
+    }
 
     argv[count] = NULL;
     return argv;
@@ -211,7 +215,10 @@ void    wait_for_all(pid_t *pids, int count)
         pid_t   last;
 
         last_status = -1;
-        last = (count > 0) ? pids[count - 1] : -1;
+        if (count > 0)
+                last = pids[count - 1];
+        else
+                last = -1;
         i = 0;
         while (i < count)
         {

--- a/src/piping/redirections.c
+++ b/src/piping/redirections.c
@@ -143,7 +143,13 @@ static int handle_redirection_logic(t_token **cmd, char **envp,
     }
     else if (cmd[*i]->type == 2) /* << */
     {
-        if (handle_heredoc(filename ? filename : "", quoted, envp, in_fd) == -1)
+        const char  *name;
+
+        if (filename)
+            name = filename;
+        else
+            name = "";
+        if (handle_heredoc(name, quoted, envp, in_fd) == -1)
             return (-1);
     }
     else if (cmd[*i]->type == 3) /* > */
@@ -167,7 +173,10 @@ static int handle_redirection_logic(t_token **cmd, char **envp,
         free_token(cmd[*i + 1]);
         cmd[*i + 1] = NULL;
     }
-    *i += filename ? 2 : 1;
+    if (filename)
+        *i += 2;
+    else
+        *i += 1;
     return (1);
 }
 


### PR DESCRIPTION
## Summary
- Replace `for` loops with equivalent `while` loops
- Expand ternary operators into explicit conditional statements

## Testing
- `make`


------
https://chatgpt.com/codex/tasks/task_e_68b04fb913ec8325b94809c9692edb74