### PR TITLE
refactor: extract tokenization helpers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,7 @@ SRCS = \
     src/parsing/redirection/redir_split.c \
     src/parsing/tokenization/split_pipes.c \
     src/parsing/tokenization/tokenize.c \
+    src/parsing/tokenization/token_utils.c \
     src/piping/pipeline.c \
     src/piping/redirections.c \
     src/piping/pipeline_setup.c \
@@ -60,7 +61,7 @@ SRCS = \
     src/main.c
 
 OBJS = $(SRCS:src/%.c=$(OBJ_PATH)%.o)
-HEADERS = includes/minishell.h
+HEADERS = includes/minishell.h includes/token_utils.h
 
 GREEN  = \033[0;32m
 YELLOW = \033[1;33m

--- a/includes/token_utils.h
+++ b/includes/token_utils.h
@@ -1,0 +1,12 @@
+#ifndef TOKEN_UTILS_H
+#define TOKEN_UTILS_H
+
+#include <stddef.h>
+
+int     fully_quoted(const char *s);
+int     is_delim(char ch, char delim);
+size_t  skip_token(const char *s, size_t i, char c);
+size_t  token_count(const char *s, char c);
+size_t  next_c(const char *s, char c);
+
+#endif

--- a/src/parsing/tokenization/token_utils.c
+++ b/src/parsing/tokenization/token_utils.c
@@ -1,0 +1,104 @@
+#include "../../libft/libft.h"
+#include "token_utils.h"
+
+int     fully_quoted(const char *s)
+{
+    size_t  len;
+    size_t  i;
+    char    quote;
+
+    if (!s)
+        return (0);
+    len = ft_strlen(s);
+    if (len < 2)
+        return (0);
+    quote = s[0];
+    if ((quote != '\'' && quote != '"') || s[len - 1] != quote)
+        return (0);
+    i = 1;
+    while (i < len - 1)
+    {
+        if (s[i] == quote)
+            return (0);
+        i++;
+    }
+    if (quote == '\'')
+        return (1);
+    return (2);
+}
+
+int     is_delim(char ch, char delim)
+{
+    if (delim == ' ')
+        return (ch == ' ' || ch == '\t');
+    return (ch == delim);
+}
+
+size_t  skip_token(const char *s, size_t i, char c)
+{
+    char quote;
+
+    quote = 0;
+    while (s[i])
+    {
+        if (!quote && (s[i] == '"' || s[i] == '\''))
+        {
+            quote = s[i++];
+            while (s[i] && s[i] != quote)
+                i++;
+            if (s[i] == quote)
+                i++;
+            quote = 0;
+            continue;
+        }
+        if (!quote && is_delim(s[i], c))
+            break;
+        i++;
+    }
+    return (i);
+}
+
+size_t  token_count(const char *s, char c)
+{
+    size_t i;
+    size_t count;
+
+    i = 0;
+    count = 0;
+    while (s[i])
+    {
+        while (is_delim(s[i], c))
+            i++;
+        if (!s[i])
+            break;
+        count++;
+        i = skip_token(s, i, c);
+    }
+    return (count);
+}
+
+size_t  next_c(const char *s, char c)
+{
+    size_t i;
+    char quote;
+
+    i = 0;
+    quote = 0;
+    while (s[i])
+    {
+        if (!quote && (s[i] == '"' || s[i] == '\''))
+        {
+            quote = s[i++];
+            while (s[i] && s[i] != quote)
+                i++;
+            if (s[i] == quote)
+                i++;
+            quote = 0;
+            continue;
+        }
+        if (!quote && is_delim(s[i], c))
+            break;
+        i++;
+    }
+    return (i);
+}

--- a/src/parsing/tokenization/tokenize.c
+++ b/src/parsing/tokenization/tokenize.c
@@ -6,118 +6,22 @@
 /*   By: dimendon <dimendon@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/08/19 11:12:49 by dimendon          #+#    #+#             */
-/*   Updated: 2025/08/25 13:24:30 by dimendon         ###   ########.fr       */
+/*   Updated: 2025/08/27 12:00:00 by dimendon         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 #include "../../libft/libft.h"
 #include "minishell.h"
-
-static int  fully_quoted(const char *s)
-{
-    size_t  len;
-    size_t  i;
-    char    quote;
-
-    if (!s)
-        return (0);
-    len = ft_strlen(s);
-    if (len < 2)
-        return (0);
-    quote = s[0];
-    if ((quote != '\'' && quote != '"') || s[len - 1] != quote)
-        return (0);
-    i = 1;
-    while (i < len - 1)
-    {
-        if (s[i] == quote)
-            return (0);
-        i++;
-    }
-    if (quote == '\'')
-        return (1);
-    return (2);
-}
-
-static int  is_delim(char ch, char delim)
-{
-    if (delim == ' ')
-        return (ch == ' ' || ch == '\t');
-    return (ch == delim);
-}
-
-static size_t skip_token(const char *s, size_t i, char c)
-{
-    char quote = 0;
-
-    while (s[i])
-    {
-        if (!quote && (s[i] == '"' || s[i] == '\''))
-        {
-            quote = s[i++];
-            while (s[i] && s[i] != quote)
-                i++;
-            if (s[i] == quote)
-                i++;
-            quote = 0;
-            continue;
-        }
-        if (!quote && is_delim(s[i], c))
-            break;
-        i++;
-    }
-    return i;
-}
-
-static size_t token_count(const char *s, char c)
-{
-    size_t i = 0;
-    size_t count = 0;
-
-    while (s[i])
-    {
-        while (is_delim(s[i], c))
-            i++;
-        if (!s[i])
-            break;
-        count++;
-        i = skip_token(s, i, c);
-    }
-    return count;
-}
-
-static size_t next_c(const char *s, char c)
-{
-    size_t i = 0;
-    char quote = 0;
-
-    while (s[i])
-    {
-        if (!quote && (s[i] == '"' || s[i] == '\''))
-        {
-            quote = s[i++];
-            while (s[i] && s[i] != quote)
-                i++;
-            if (s[i] == quote)
-                i++;
-            quote = 0;
-            continue;
-        }
-        if (!quote && is_delim(s[i], c))
-            break;
-        i++;
-    }
-    return i;
-}
+#include "token_utils.h"
 
 static t_token **fill_arr_from_string(const char *s, char c)
 {
     t_token **arr;
-    int token_num;
-    int i;
-    size_t len;
-    int type;
-    int quoted;
-    char *substr;
+    int     token_num;
+    int     i;
+    size_t  len;
+    int     type;
+    int     quoted;
+    char    *substr;
 
     token_num = token_count(s, c);
     arr = malloc(sizeof(t_token *) * (token_num + 1));
@@ -136,35 +40,32 @@ static t_token **fill_arr_from_string(const char *s, char c)
         substr = ft_substr(s, 0, len);
         if (!substr)
         {
-            arr[i] = NULL;          // ensure free_tokens sees a terminator
+            arr[i] = NULL;
             free_tokens(arr);
             return (NULL);
         }
 
-        // use the robust detector
         quoted = fully_quoted(substr);
-
         type = 0;
         arr[i++] = new_token(substr, quoted, type);
         free(substr);
-
         s += len;
     }
     arr[i] = NULL;
-    return arr;
+    return (arr);
 }
 
 t_token **tokenize_command(char const *s, char c, char **envp)
 {
     t_token **arr;
-    int i;
+    int     i;
 
     if (!s)
-        return NULL;
+        return (NULL);
 
     arr = fill_arr_from_string(s, c);
     if (!arr)
-        return NULL;
+        return (NULL);
 
     i = 0;
     while (arr[i])
@@ -175,7 +76,7 @@ t_token **tokenize_command(char const *s, char c, char **envp)
             if (!expanded)
             {
                 free_tokens(arr);
-                return NULL;
+                return (NULL);
             }
             free(arr[i]->str);
             arr[i]->str = expanded;
@@ -186,31 +87,29 @@ t_token **tokenize_command(char const *s, char c, char **envp)
     }
     arr = split_expanded_tokens(arr);
     if (!arr)
-        return NULL;
+        return (NULL);
 
     arr = split_redirs(arr);
     if (!arr)
-        return NULL;
+        return (NULL);
 
-    return arr;
+    return (arr);
 }
 
 t_token *new_token(const char *str, int quoted, int type)
 {
-    t_token *tok = malloc(sizeof(t_token));
+    t_token *tok;
+
+    tok = malloc(sizeof(t_token));
     if (!tok)
-        return NULL;
+        return (NULL);
     tok->str = ft_strdup(str);
     if (!tok->str)
     {
         free(tok);
-        return NULL;
+        return (NULL);
     }
     tok->quoted = quoted;
     tok->type = type;
-    return tok;
+    return (tok);
 }
-
-
-
-


### PR DESCRIPTION
## Summary
- Move low-level token helpers into dedicated token_utils module
- Keep high-level tokenization routines in tokenize.c
- Update build to compile new token_utils and header

## Testing
- `make`
- `make fclean`


------
https://chatgpt.com/codex/tasks/task_e_68b06a97d0348325936e22ca9b356a2b