### PR TITLE
Trim builtin command names before comparison

### DIFF
--- a/src/execution/command_processor.c
+++ b/src/execution/command_processor.c
@@ -14,26 +14,32 @@
 #include "minishell.h"
 #include <fcntl.h>
 
-int	run_builtin(char ***envp, t_token **cmd)
+int     run_builtin(char ***envp, t_token **cmd)
 {
 	char	*name;
+	char	*trimmed;
 
 	if (!cmd || !cmd[0] || !cmd[0]->str)
 		return (127);
+	trimmed = ft_strtrim(cmd[0]->str, " \t\n\r\v\f");
+	if (!trimmed)
+		return (127);
+	free(cmd[0]->str);
+	cmd[0]->str = trimmed;
 	name = cmd[0]->str;
-	if (!ft_strncmp(name, "echo", 5))
+	if (!ft_strcmp(name, "echo"))
 		g_exit_code = custom_echo(cmd);
-	else if (!ft_strncmp(name, "cd", 3))
+	else if (!ft_strcmp(name, "cd"))
 		g_exit_code = custom_cd(envp, cmd);
-	else if (!ft_strncmp(name, "pwd", 4))
+	else if (!ft_strcmp(name, "pwd"))
 		g_exit_code = custom_pwd();
-	else if (!ft_strncmp(name, "export", 7))
+	else if (!ft_strcmp(name, "export"))
 		g_exit_code = custom_export(envp, cmd);
-	else if (!ft_strncmp(name, "unset", 6))
+	else if (!ft_strcmp(name, "unset"))
 		g_exit_code = custom_unset(envp, cmd);
-	else if (!ft_strncmp(name, "env", 4))
+	else if (!ft_strcmp(name, "env"))
 		g_exit_code = custom_env(*envp, cmd);
-	else if (!ft_strncmp(name, "exit", 5))
+	else if (!ft_strcmp(name, "exit"))
 	{
 		g_exit_code = custom_exit(cmd);
 		if (g_exit_code != 1)

--- a/src/execution/command_utils.c
+++ b/src/execution/command_utils.c
@@ -126,11 +126,21 @@ void restore_redirections(int save_in, int save_out)
     }
 }
 
-short int is_builtin(const char *cmd)
+short int	is_builtin(const char *cmd)
 {
-    return (ft_strncmp(cmd, "echo", 5) == 0 || ft_strncmp(cmd, "cd", 3) == 0
-        || ft_strncmp(cmd, "pwd", 4) == 0 || ft_strncmp(cmd, "export", 7) == 0
-        || ft_strncmp(cmd, "unset", 6) == 0 || ft_strncmp(cmd, "env", 4) == 0
-        || ft_strncmp(cmd, "exit", 5) == 0);
+	char		*trimmed;
+	short int	result;
+
+	if (!cmd)
+		return (0);
+	trimmed = ft_strtrim(cmd, " \t\n\r\v\f");
+	if (!trimmed)
+		return (0);
+	result = (!ft_strcmp(trimmed, "echo") || !ft_strcmp(trimmed, "cd")
+		|| !ft_strcmp(trimmed, "pwd") || !ft_strcmp(trimmed, "export")
+		|| !ft_strcmp(trimmed, "unset") || !ft_strcmp(trimmed, "env")
+		|| !ft_strcmp(trimmed, "exit"));
+	free(trimmed);
+	return (result);
 }
 


### PR DESCRIPTION
## Summary
- Trim command names before builtin lookup
- Compare builtin names exactly with `ft_strcmp`
- Centralize whitespace stripping for builtin detection

## Testing
- `make`
- `./parsing-hell` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b0917832408325bf565d232c26d9ad