### PR TITLE
Handle variable names split by quotes in expansion

### DIFF
--- a/src/parsing/expansion/expander.c
+++ b/src/parsing/expansion/expander.c
@@ -1,105 +1,146 @@
 #include "../../libft/libft.h"
 #include "minishell.h"
 
-static char	*append_exit_code(char *result, int *i, char *str, int *handled)
+static char *append_exit_code(char *result, int *i, char *str, int *handled)
 {
-	char	*exit_code_str;
-	char	*tmp;
+    char    *exit_code_str;
+    char    *tmp;
 
-	*handled = 0;
-	if (!(str[*i] == '$' && str[*i + 1] == '?'))
-		return (result);
-	*handled = 1;
-	if (!(result = append_literal(result, str, 0, *i)))
-		return (NULL);
-	exit_code_str = ft_itoa(g_exit_code);
-	if (!exit_code_str)
-		return (free(result), NULL);
-	tmp = ft_strcatrealloc(result, exit_code_str);
-	free(exit_code_str);
-	if (!tmp)
-		return (free(result), NULL);
-	result = tmp;
-	*i += 2;
-	return (result);
+    *handled = 0;
+    if (!(str[*i] == '$' && str[*i + 1] == '?'))
+        return (result);
+    *handled = 1;
+    if (!(result = append_literal(result, str, 0, *i)))
+        return (NULL);
+    exit_code_str = ft_itoa(g_exit_code);
+    if (!exit_code_str)
+        return (free(result), NULL);
+    tmp = ft_strcatrealloc(result, exit_code_str);
+    free(exit_code_str);
+    if (!tmp)
+        return (free(result), NULL);
+    result = tmp;
+    *i += 2;
+    return (result);
 }
 
-static void	update_quote(char c, char *quote, int *i)
+static void update_quote(char c, char *quote, int *i)
 {
-	if (!*quote && (c == '\'' || c == '"'))
-	{
-		*quote = c;
-		(*i)++;
-	}
-	else if (*quote && c == *quote)
-	{
-		*quote = 0;
-		(*i)++;
-	}
+    if (!*quote && (c == '\'' || c == '"'))
+    {
+        *quote = c;
+        (*i)++;
+    }
+    else if (*quote && c == *quote)
+    {
+        *quote = 0;
+        (*i)++;
+    }
 }
 
-static int	process_dollar(char **res, char *str, int *i, int *start,
-		char **envp)
+static char *collect_var_name(char *str, int *i)
 {
-	int	handled;
+    int     j;
+    char    quote;
+    char    *name;
+    char    tmp[2];
 
-	*res = append_exit_code(*res, i, str, &handled);
-	if (!*res)
-		return (-1);
-	if (handled)
-	{
-		*start = *i;
-		return (1);
-	}
-	if (ft_isalnum(str[*i + 1]) || str[*i + 1] == '_')
-	{
-		if (!(*res = append_literal(*res, str, *start, *i)))
-			return (-1);
-		if (!(*res = append_expanded_var(*res, str, i, envp)))
-			return (-1);
-		*start = *i;
-		return (1);
-	}
-	return (0);
+    j = *i + 1;
+    quote = 0;
+    name = NULL;
+    while (str[j])
+    {
+        if (!quote && (str[j] == '\'' || str[j] == '"'))
+        {
+            quote = str[j++];
+            continue;
+        }
+        if (quote && str[j] == quote)
+        {
+            quote = 0;
+            j++;
+            continue;
+        }
+        if (ft_isalnum(str[j]) || str[j] == '_')
+        {
+            tmp[0] = str[j++];
+            tmp[1] = '\0';
+            name = ft_strcatrealloc(name, tmp);
+            if (!name)
+                return (NULL);
+            continue;
+        }
+        break;
+    }
+    *i = j;
+    return (name);
 }
 
-char	*build_expanded_str(char *str, char **envp)
+static int process_dollar(char **res, char *str, int *i, int *start, char **envp)
 {
-	int		i;
-	int		start;
-	char	quote;
-	char	*result;
-	int		handled;
+    int     handled;
+    char    *name;
+    char    *value;
+    char    *tmp;
 
-	i = 0;
-	start = 0;
-	quote = 0;
-	result = NULL;
-	while (str[i])
-	{
-		if (!quote && str[i] == '$' && (str[i + 1] == '"'))
-		{
-			if (!(result = append_literal(result, str, start, i)))
-				return (NULL);
-			i++;
-			start = i;
-			continue ;
-		}
-		handled = i;
-		update_quote(str[i], &quote, &i);
-		if (i != handled)
-			continue ;
-		if (str[i] == '$' && quote != '\'')
-		{
-			handled = process_dollar(&result, str, &i, &start, envp);
-			if (handled == -1)
-				return (NULL);
-			if (handled)
-				continue ;
-		}
-		i++;
-	}
-	if (!(result = ft_strcatrealloc(result, str + start)))
-		return (NULL);
-	return (result);
+    *res = append_exit_code(*res, i, str, &handled);
+    if (!*res && handled)
+        return (-1);
+    if (handled)
+    {
+        *start = *i;
+        return (1);
+    }
+    if (ft_isalnum(str[*i + 1]) || str[*i + 1] == '_' || str[*i + 1] == '\'' || str[*i + 1] == '"')
+    {
+        if (!(*res = append_literal(*res, str, *start, *i)))
+            return (-1);
+        name = collect_var_name(str, i);
+        if (!name)
+            return (-1);
+        value = get_env_value(envp, name);
+        free(name);
+        if (!value)
+            value = "";
+        tmp = ft_strcatrealloc(*res, value);
+        if (!tmp)
+            return (-1);
+        *res = tmp;
+        *start = *i;
+        return (1);
+    }
+    return (0);
+}
+
+char *build_expanded_str(char *str, char **envp)
+{
+    int     i;
+    int     start;
+    char    quote;
+    char    *result;
+    int     handled;
+
+    i = 0;
+    start = 0;
+    quote = 0;
+    result = NULL;
+    while (str[i])
+    {
+        handled = i;
+        update_quote(str[i], &quote, &i);
+        if (i != handled)
+            continue;
+        if (str[i] == '$' && quote != '\'')
+        {
+            handled = process_dollar(&result, str, &i, &start, envp);
+            if (handled == -1)
+                return (NULL);
+            if (handled)
+                continue;
+        }
+        i++;
+    }
+    if (!(result = ft_strcatrealloc(result, str + start)))
+        return (NULL);
+    return (result);
 }

--- a/tests/expansion_tests.c
+++ b/tests/expansion_tests.c
@@ -1,0 +1,27 @@
+#include <assert.h>
+#include <string.h>
+#include <stdio.h>
+#include "../includes/minishell.h"
+#include "../src/libft/libft.h"
+
+int g_exit_code = 0;
+
+static void run_case(const char *input, const char *expected, char **env)
+{
+    char *dup = ft_strdup(input);
+    char *res = build_expanded_str(dup, env);
+    free(dup);
+    printf("input: %s -> %s\n", input, res ? res : "(null)");
+    assert(res && strcmp(res, expected) == 0);
+    free(res);
+}
+
+int main(void)
+{
+    char *env[] = {"USER=testuser", NULL};
+    run_case("$USER", "testuser", env);
+    run_case("$US\"E\"R", "testuser", env);
+    run_case("$U'S'E'R", "testuser", env);
+    printf("All expansion tests passed\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- expand env variable names split by quotes as a single identifier
- add regression tests for quoted variable names

## Testing
- `make`
- `cc -Wall -Wextra -Werror -I./includes -I./src/libft tests/expansion_tests.c src/parsing/expansion/expander.c src/parsing/expansion/expander_utils.c src/env/env_lookup.c -Lsrc/libft -lft -o tests/expansion_tests && ./tests/expansion_tests && rm tests/expansion_tests`


------
https://chatgpt.com/codex/tasks/task_e_68b0917984988325afb57ae08a2c3a9f