### PR TITLE
Fix quote handling around variable expansion

### DIFF
--- a/src/parsing/expansion/expander.c
+++ b/src/parsing/expansion/expander.c
@@ -41,26 +41,15 @@ static void update_quote(char c, char *quote, int *i)
 static char *collect_var_name(char *str, int *i)
 {
     int     j;
-    char    quote;
     char    *name;
     char    tmp[2];
 
     j = *i + 1;
-    quote = 0;
     name = NULL;
     while (str[j])
     {
-        if (!quote && (str[j] == '\'' || str[j] == '"'))
-        {
-            quote = str[j++];
-            continue;
-        }
-        if (quote && str[j] == quote)
-        {
-            quote = 0;
-            j++;
-            continue;
-        }
+        if (str[j] == '\'' || str[j] == '"')
+            break;
         if (ft_isalnum(str[j]) || str[j] == '_')
         {
             tmp[0] = str[j++];
@@ -91,7 +80,7 @@ static int process_dollar(char **res, char *str, int *i, int *start, char **envp
         *start = *i;
         return (1);
     }
-    if (ft_isalnum(str[*i + 1]) || str[*i + 1] == '_' || str[*i + 1] == '\'' || str[*i + 1] == '"')
+    if (ft_isalnum(str[*i + 1]) || str[*i + 1] == '_')
     {
         if (!(*res = append_literal(*res, str, *start, *i)))
             return (-1);

--- a/tests/expansion_tests.c
+++ b/tests/expansion_tests.c
@@ -11,6 +11,8 @@ static void run_case(const char *input, const char *expected, char **env)
     char *dup = ft_strdup(input);
     char *res = build_expanded_str(dup, env);
     free(dup);
+    if (res)
+        remove_quotes(res);
     printf("input: %s -> %s\n", input, res ? res : "(null)");
     assert(res && strcmp(res, expected) == 0);
     free(res);
@@ -20,8 +22,9 @@ int main(void)
 {
     char *env[] = {"USER=testuser", NULL};
     run_case("$USER", "testuser", env);
-    run_case("$US\"E\"R", "testuser", env);
-    run_case("$U'S'E'R", "testuser", env);
+    run_case("\"$USER\"", "testuser", env);
+    run_case("$US\"E\"R", "ER", env);
+    run_case("$U'S'E'R", "SER", env);
     printf("All expansion tests passed\n");
     return 0;
 }


### PR DESCRIPTION
## Summary
- stop treating quotes as variable-name characters during expansion
- keep quotes adjacent to variables so `remove_quotes` can strip them
- update expansion tests for new quote behavior

## Testing
- `make`
- `./tests/expansion_tests`
- `tests/echo_n_flags.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b1b88da3088325bf1edd150458b3a3