### PR TITLE
Treat backslashes as literals in quote removal

### DIFF
--- a/src/parsing/expansion/expander.c
+++ b/src/parsing/expansion/expander.c
@@ -115,6 +115,15 @@ char *build_expanded_str(char *str, char **envp)
     result = NULL;
     while (str[i])
     {
+        if (!quote && str[i] == '$' && str[i + 1] == '"')
+        {
+            if (!(result = append_literal(result, str, start, i)))
+                return (NULL);
+            start = i + 1;
+            i++;
+            update_quote(str[i], &quote, &i);
+            continue;
+        }
         handled = i;
         update_quote(str[i], &quote, &i);
         if (i != handled)

--- a/src/parsing/expansion/expander_utils.c
+++ b/src/parsing/expansion/expander_utils.c
@@ -12,12 +12,6 @@ void    remove_quotes(char *str)
         j = 0;
         while (str[i])
         {
-                if (quote != '\'' && str[i] == '\\' && str[i + 1])
-                {
-                        str[j++] = str[++i];
-                        i++;
-                        continue ;
-                }
                 if (!quote && (str[i] == '\'' || str[i] == '"'))
                         quote = str[i++];
                 else if (quote && str[i] == quote)

--- a/tests/expansion_tests.c
+++ b/tests/expansion_tests.c
@@ -25,6 +25,10 @@ int main(void)
     run_case("\"$USER\"", "testuser", env);
     run_case("$US\"E\"R", "ER", env);
     run_case("$U'S'E'R", "SER", env);
+    run_case("$\"HOME\"$USER", "HOMEtestuser", env);
+    run_case("$\"HOM\"E$USER", "HOMEtestuser", env);
+    run_case("$\"HOME\"", "HOME", env);
+    run_case("$\"42$\"", "42$", env);
     printf("All expansion tests passed\n");
     return 0;
 }


### PR DESCRIPTION
## Summary
- stop interpreting backslashes as escape characters when stripping quotes
- support $"" translation strings by skipping the leading $

## Testing
- `make`
- `./tests/echo_n_flags.sh`
- `cc tests/expansion_tests.c src/parsing/expansion/expander.c src/parsing/expansion/expander_utils.c src/env/env_lookup.c src/libft/libft.a -I includes -I src/libft -o tests/expansion_tests && ./tests/expansion_tests`


------
https://chatgpt.com/codex/tasks/task_e_68b1c410e72883258378b5dda213ac76