### PR TITLE
Fix command dispatch trimming for builtins

### DIFF
--- a/src/execution/command_processor.c
+++ b/src/execution/command_processor.c
@@ -16,17 +16,11 @@
 
 int     run_builtin(char ***envp, t_token **cmd)
 {
-	char	*name;
-	char	*trimmed;
+        char    *name;
 
-	if (!cmd || !cmd[0] || !cmd[0]->str)
-		return (127);
-	trimmed = ft_strtrim(cmd[0]->str, " \t\n\r\v\f");
-	if (!trimmed)
-		return (127);
-	free(cmd[0]->str);
-	cmd[0]->str = trimmed;
-	name = cmd[0]->str;
+        if (!cmd || !cmd[0] || !cmd[0]->str)
+                return (127);
+        name = cmd[0]->str;
 	if (!ft_strcmp(name, "echo"))
 		g_exit_code = custom_echo(cmd);
 	else if (!ft_strcmp(name, "cd"))


### PR DESCRIPTION
## Summary
- Avoid trimming command names before builtin dispatch to respect literal spaces

## Testing
- `cc tests/expansion_tests.c src/parsing/expansion/expander.c src/parsing/expansion/expander_utils.c src/utils/cleanup.c src/utils/array_utils.c src/env/env_lookup.c src/env/env_utils.c -Iincludes -Isrc/libft -Lsrc/libft -lft -o tests/expansion_tests`
- `tests/expansion_tests`

------
https://chatgpt.com/codex/tasks/task_e_68b1c9bff6388325af4213bf251615c4