### PR TITLE
Handle whitespace from quoted expansions

### DIFF
--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -128,6 +128,7 @@ t_token     **split_redirs(t_token **arr);
 
 // Expansion
 void        remove_quotes(char *str);
+void        restore_marked_spaces(char *str);
 char        *append_literal(char *result, char *str, int start, int i);
 char        *expand_var(char *str, int *var_len);
 char        *append_expanded_var(char *result, char *str, int *i, char **envp);

--- a/src/execution/command_processor.c
+++ b/src/execution/command_processor.c
@@ -16,38 +16,38 @@
 
 int     run_builtin(char ***envp, t_token **cmd)
 {
-	char	*name;
-	char	*trimmed;
+        char    *name;
+        char    *trimmed;
 
-	if (!cmd || !cmd[0] || !cmd[0]->str)
-		return (127);
-	trimmed = ft_strtrim(cmd[0]->str, " \t\n\r\v\f");
-	if (!trimmed)
-		return (127);
-	free(cmd[0]->str);
-	cmd[0]->str = trimmed;
-	name = cmd[0]->str;
-	if (!ft_strcmp(name, "echo"))
-		g_exit_code = custom_echo(cmd);
-	else if (!ft_strcmp(name, "cd"))
-		g_exit_code = custom_cd(envp, cmd);
-	else if (!ft_strcmp(name, "pwd"))
-		g_exit_code = custom_pwd();
-	else if (!ft_strcmp(name, "export"))
-		g_exit_code = custom_export(envp, cmd);
-	else if (!ft_strcmp(name, "unset"))
-		g_exit_code = custom_unset(envp, cmd);
-	else if (!ft_strcmp(name, "env"))
-		g_exit_code = custom_env(*envp, cmd);
-	else if (!ft_strcmp(name, "exit"))
-	{
-		g_exit_code = custom_exit(cmd);
-		if (g_exit_code != 1)
-			exit(g_exit_code);
-	}
-	else
-		g_exit_code = 127;
-	return (g_exit_code);
+        if (!cmd || !cmd[0] || !cmd[0]->str)
+                return (127);
+        trimmed = ft_strtrim(cmd[0]->str, " \t\n\r\v\f");
+        if (!trimmed)
+                return (127);
+        free(cmd[0]->str);
+        cmd[0]->str = trimmed;
+        name = cmd[0]->str;
+        if (!ft_strcmp(name, "echo"))
+                g_exit_code = custom_echo(cmd);
+        else if (!ft_strcmp(name, "cd"))
+                g_exit_code = custom_cd(envp, cmd);
+        else if (!ft_strcmp(name, "pwd"))
+                g_exit_code = custom_pwd();
+        else if (!ft_strcmp(name, "export"))
+                g_exit_code = custom_export(envp, cmd);
+        else if (!ft_strcmp(name, "unset"))
+                g_exit_code = custom_unset(envp, cmd);
+        else if (!ft_strcmp(name, "env"))
+                g_exit_code = custom_env(*envp, cmd);
+        else if (!ft_strcmp(name, "exit"))
+        {
+                g_exit_code = custom_exit(cmd);
+                if (g_exit_code != 1)
+                        exit(g_exit_code);
+        }
+        else
+                g_exit_code = 127;
+        return (g_exit_code);
 }
 
 static void	execute_command_with_path(t_token **cmd, char ***envp)

--- a/src/parsing/expansion/expander_utils.c
+++ b/src/parsing/expansion/expander_utils.c
@@ -1,75 +1,110 @@
 #include "../../libft/libft.h"
 #include "minishell.h"
 
+#define SPACE_MARK 1
+
+static void mark_quoted_spaces(char *str)
+{
+    char    quote;
+    size_t  i;
+
+    quote = 0;
+    i = 0;
+    while (str[i])
+    {
+        if (!quote && (str[i] == '\'' || str[i] == '"'))
+            quote = str[i];
+        else if (quote && str[i] == quote)
+            quote = 0;
+        else if (quote && str[i] == ' ')
+            str[i] = SPACE_MARK;
+        i++;
+    }
+}
+
 void    remove_quotes(char *str)
 {
-        char    quote;
-        size_t  i;
-        size_t  j;
+    char    quote;
+    size_t  i;
+    size_t  j;
 
-        quote = 0;
-        i = 0;
-        j = 0;
-        while (str[i])
+    mark_quoted_spaces(str);
+
+    quote = 0;
+    i = 0;
+    j = 0;
+    while (str[i])
+    {
+        if (!quote && (str[i] == '\'' || str[i] == '"'))
+            quote = str[i++];
+        else if (quote && str[i] == quote)
         {
-                if (!quote && (str[i] == '\'' || str[i] == '"'))
-                        quote = str[i++];
-                else if (quote && str[i] == quote)
-                {
-                        quote = 0;
-                        i++;
-                }
-                else
-                        str[j++] = str[i++];
+            quote = 0;
+            i++;
         }
-        str[j] = '\0';
+        else
+            str[j++] = str[i++];
+    }
+    str[j] = '\0';
+}
+
+void    restore_marked_spaces(char *str)
+{
+    size_t  i;
+
+    i = 0;
+    while (str[i])
+    {
+        if (str[i] == SPACE_MARK)
+            str[i] = ' ';
+        i++;
+    }
 }
 
 char    *append_literal(char *result, char *str, int start, int i)
 {
-        char    *tmp;
+    char    *tmp;
 
-        str[i] = '\0';
-        tmp = ft_strcatrealloc(result, str + start);
-        str[i] = '$';
-        if (!tmp)
-        {
-                free(result);
-                return (NULL);
-        }
-        return (tmp);
+    str[i] = '\0';
+    tmp = ft_strcatrealloc(result, str + start);
+    str[i] = '$';
+    if (!tmp)
+    {
+        free(result);
+        return (NULL);
+    }
+    return (tmp);
 }
 
 char    *expand_var(char *str, int *var_len)
 {
-        int     i;
+    int     i;
 
-        i = 0;
-        while (str[i] != '\0' && (ft_isalnum(str[i]) || str[i] == '_'))
-                i++;
-        *var_len = i;
-        if (i > 0)
-                return (ft_substr(str, 0, i));
-        return (NULL);
+    i = 0;
+    while (str[i] != '\0' && (ft_isalnum(str[i]) || str[i] == '_'))
+        i++;
+    *var_len = i;
+    if (i > 0)
+        return (ft_substr(str, 0, i));
+    return (NULL);
 }
 
 char    *append_expanded_var(char *result, char *str, int *i, char **envp)
 {
-        int             var_len;
-        char            *var;
-        char            *value;
-        char            *tmp;
+    int             var_len;
+    char            *var;
+    char            *value;
+    char            *tmp;
 
-        var_len = 0;
-        var = expand_var(&str[*i + 1], &var_len);
-        value = get_env_value(envp, var);
-        if (!value)
-                value = "";
-        tmp = ft_strcatrealloc(result, value);
-        free(var);
-        if (!tmp)
-                return (NULL);
-        *i += var_len + 1;
-        return (tmp);
+    var_len = 0;
+    var = expand_var(&str[*i + 1], &var_len);
+    value = get_env_value(envp, var);
+    if (!value)
+        value = "";
+    tmp = ft_strcatrealloc(result, value);
+    free(var);
+    if (!tmp)
+        return (NULL);
+    *i += var_len + 1;
+    return (tmp);
 }
-

--- a/src/parsing/expansion/word_split.c
+++ b/src/parsing/expansion/word_split.c
@@ -90,21 +90,28 @@ static int	expand_token(t_token **out, t_token *tok, int *k)
 	char	**parts;
 	int		j;
 
-	if (tok->quoted)
-	{
-		out[(*k)++] = tok;
-		return (0);
-	}
-	parts = split_whitespace(tok->str);
-	free(tok->str);
-	free(tok);
-	if (!parts)
-		return (1);
-	j = 0;
-	while (parts[j])
-		out[(*k)++] = new_token(parts[j++], 0, 0);
-	free(parts);
-	return (0);
+        if (tok->quoted)
+        {
+                restore_marked_spaces(tok->str);
+                out[(*k)++] = tok;
+                return (0);
+        }
+        parts = split_whitespace(tok->str);
+        free(tok->str);
+        free(tok);
+        if (!parts)
+                return (1);
+        j = 0;
+        while (parts[j])
+        {
+                out[(*k)] = new_token(parts[j], 0, 0);
+                if (!out[(*k)])
+                        return (free_cmd(parts), 1);
+                restore_marked_spaces(out[(*k)++]->str);
+                j++;
+        }
+        free(parts);
+        return (0);
 }
 
 t_token	**split_expanded_tokens(t_token **arr)

--- a/src/parsing/tokenization/tokenize.c
+++ b/src/parsing/tokenization/tokenize.c
@@ -47,6 +47,8 @@ static int      populate_tokens(t_token **arr, const char *s, char c)
                         return (1);
                 }
                 quoted = fully_quoted(substr);
+                if (!quoted && (ft_strchr(substr, '"') || ft_strchr(substr, '\'')))
+                        quoted = 3;
                 type = 0;
                 arr[i] = new_token(substr, quoted, type);
                 free(substr);
@@ -92,8 +94,12 @@ static int      expand_all(t_token **arr, char **envp)
                         free(arr[i]->str);
                         arr[i]->str = expanded;
                 }
-                if (ft_strchr(arr[i]->str, '"') || ft_strchr(arr[i]->str, '\''))
-                        remove_quotes(arr[i]->str);
+		if (ft_strchr(arr[i]->str, '"') || ft_strchr(arr[i]->str, '\''))
+		{
+			remove_quotes(arr[i]->str);
+			if (arr[i]->quoted == 3)
+				arr[i]->quoted = 0;
+		}
                 i++;
         }
         return (0);


### PR DESCRIPTION
## Summary
- Preserve spaces that originate inside quotes before removing them so that word-splitting happens only on truly unquoted whitespace
- Restore marked spaces after expansion and split tokens accordingly
- Expose helper to restore marked spaces for post-expansion processing

## Testing
- `cc tests/expansion_tests.c src/parsing/expansion/expander.c src/parsing/expansion/expander_utils.c src/utils/cleanup.c src/utils/array_utils.c src/env/env_lookup.c src/env/env_utils.c -Iincludes -Isrc/libft -Lsrc/libft -lft -o tests/expansion_tests`
- `tests/expansion_tests`
- `make minishell`

------
https://chatgpt.com/codex/tasks/task_e_68b1c9bff6388325af4213bf251615c4