### PR TITLE
Avoid treating whitespace-padded command names as builtins

### DIFF
--- a/src/execution/command_processor.c
+++ b/src/execution/command_processor.c
@@ -17,16 +17,14 @@
 int     run_builtin(char ***envp, t_token **cmd)
 {
         char    *name;
-        char    *trimmed;
 
         if (!cmd || !cmd[0] || !cmd[0]->str)
                 return (127);
-        trimmed = ft_strtrim(cmd[0]->str, " \t\n\r\v\f");
-        if (!trimmed)
-                return (127);
-        free(cmd[0]->str);
-        cmd[0]->str = trimmed;
         name = cmd[0]->str;
+        /*
+         * Use the command name verbatim so that quoted names with trailing
+         * whitespace aren't mistaken for builtins.
+         */
         if (!ft_strcmp(name, "echo"))
                 g_exit_code = custom_echo(cmd);
         else if (!ft_strcmp(name, "cd"))

--- a/src/execution/command_utils.c
+++ b/src/execution/command_utils.c
@@ -126,21 +126,25 @@ void restore_redirections(int save_in, int save_out)
     }
 }
 
-short int	is_builtin(const char *cmd)
+short int       is_builtin(const char *cmd)
 {
-	char		*trimmed;
-	short int	result;
-
-	if (!cmd)
-		return (0);
-	trimmed = ft_strtrim(cmd, " \t\n\r\v\f");
-	if (!trimmed)
-		return (0);
-	result = (!ft_strcmp(trimmed, "echo") || !ft_strcmp(trimmed, "cd")
-		|| !ft_strcmp(trimmed, "pwd") || !ft_strcmp(trimmed, "export")
-		|| !ft_strcmp(trimmed, "unset") || !ft_strcmp(trimmed, "env")
-		|| !ft_strcmp(trimmed, "exit"));
-	free(trimmed);
-	return (result);
+        if (!cmd)
+                return (0);
+        /*
+         * Reject names containing any whitespace so quoted commands like
+         * "echo " are executed externally instead of dispatching to builtins.
+         */
+        if (ft_strchr(cmd, ' ') || ft_strchr(cmd, '\t')
+                || ft_strchr(cmd, '\n') || ft_strchr(cmd, '\r')
+                || ft_strchr(cmd, '\v') || ft_strchr(cmd, '\f'))
+                return (0);
+        return (!ft_strcmp((char *)cmd, "echo")
+                || !ft_strcmp((char *)cmd, "cd")
+                || !ft_strcmp((char *)cmd, "pwd")
+                || !ft_strcmp((char *)cmd, "export")
+                || !ft_strcmp((char *)cmd, "unset")
+                || !ft_strcmp((char *)cmd, "env")
+                || !ft_strcmp((char *)cmd, "exit"));
 }
+
 


### PR DESCRIPTION
## Summary
- Preserve exact command strings when dispatching builtins
- Reject builtin dispatch for names containing whitespace
- Document whitespace handling in builtin checks

## Testing
- `make`
- `bash tests/echo_n_flags.sh`
- `printf '"echo "\n' | ./minishell >out.txt 2>err.txt; echo $?; cat out.txt; cat err.txt`


------
https://chatgpt.com/codex/tasks/task_e_68b1da59fdb483258715ce8588963adf